### PR TITLE
Global creds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>sysdig-secure</artifactId>
-  <version>1.0.19.4-SNAPSHOT</version>
+  <version>1.0.20.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Sysdig Secure Container Image Scanner Plugin</name>
   <description>Integrates Jenkins with the Sysdig Secure Image Scanner to scan Docker images</description>
@@ -41,7 +41,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>sysdig-secure-1.0.19.3</tag>
+    <tag>sysdig-secure-1.0.20.1</tag>
   </scm>
   <repositories>
     <repository>

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/AnchoreBuilder.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/AnchoreBuilder.java
@@ -288,10 +288,12 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
       /* Fetch Jenkins creds first, can't push this lower down the chain since it requires Jenkins instance object */
       String engineuser = "";
       String enginepass = "";
+      // We are expecting that either the job credentials or global credentials will be set, otherwise, fail the build
       if (Strings.isNullOrEmpty(engineCredentialsId) && Strings.isNullOrEmpty(globalConfig.getEngineCredentialsId())){
           throw new AbortException("Cannot find Jenkins credentials by ID: \'" + engineCredentialsId
                   + "\'. Ensure credentials are defined in Jenkins before using them");
       }
+      //Prefer the job credentials set by the user and fallback to the global ones
       String credID = !Strings.isNullOrEmpty(engineCredentialsId)? engineCredentialsId : globalConfig.getEngineCredentialsId();
       console.logDebug("Processing Jenkins credential ID " + credID);
         try {
@@ -299,9 +301,11 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
           CredentialsProvider.findCredentialById(
                   credID,
                   StandardUsernamePasswordCredentials.class,
-                run,
+                  run,
                   Collections.<DomainRequirement>emptyList());
           if (null != creds) {
+              //This is to maintain backward compatibility with how the API layer fetching the information. This will be changed in the next version to use 
+              //the Authorization header instead.  
               engineuser = creds.getPassword().getPlainText();
               enginepass = "";
           } else {

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/AnchoreBuilder.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/AnchoreBuilder.java
@@ -286,27 +286,33 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
     try {
 
       /* Fetch Jenkins creds first, can't push this lower down the chain since it requires Jenkins instance object */
-      String engineuser = null;
-      String enginepass = null;
-      if (!Strings.isNullOrEmpty(engineCredentialsId)) {
-        console.logDebug("Found build override for sysdig-secure-engine credentials. Processing Jenkins credential ID ");
+      String engineuser = "";
+      String enginepass = "";
+      if (Strings.isNullOrEmpty(engineCredentialsId) && Strings.isNullOrEmpty(globalConfig.getEngineCredentialsId())){
+          throw new AbortException("Cannot find Jenkins credentials by ID: \'" + engineCredentialsId
+                  + "\'. Ensure credentials are defined in Jenkins before using them");
+      }
+      String credID = !Strings.isNullOrEmpty(engineCredentialsId)? engineCredentialsId : globalConfig.getEngineCredentialsId();
+      console.logDebug("Processing Jenkins credential ID " + credID);
         try {
-          StandardUsernamePasswordCredentials creds = CredentialsProvider
-              .findCredentialById(engineCredentialsId, StandardUsernamePasswordCredentials.class, run,
+          StandardUsernamePasswordCredentials creds =
+          CredentialsProvider.findCredentialById(
+                  credID,
+                  StandardUsernamePasswordCredentials.class,
+                run,
                   Collections.<DomainRequirement>emptyList());
           if (null != creds) {
-            engineuser = creds.getUsername();
-            enginepass = creds.getPassword().getPlainText();
+              engineuser = creds.getPassword().getPlainText();
+              enginepass = "";
           } else {
-            throw new AbortException("Cannot find Jenkins credentials by ID: \'" + engineCredentialsId
+            throw new AbortException("Cannot find Jenkins credentials by ID: \'" + credID
                 + "\'. Ensure credentials are defined in Jenkins before using them");
           }
         } catch (AbortException e) {
           throw e;
         } catch (Exception e) {
-          console.logError("Error looking up Jenkins credentials by ID: \'" + engineCredentialsId + "\'", e);
-          throw new AbortException("Error looking up Jenkins credentials by ID: \'" + engineCredentialsId);
-        }
+          console.logError("Error looking up Jenkins credentials by ID: \'" + credID + "\'", e);
+          throw new AbortException("Error looking up Jenkins credentials by ID: \'" + credID);
       }
 
       /* Instantiate config and a new build worker */
@@ -315,8 +321,8 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
           annotations, globalConfig.getDebug(), globalConfig.getEnginemode(),
           // messy build time overrides, ugh!
           !Strings.isNullOrEmpty(engineurl) ? engineurl : globalConfig.getEngineurl(),
-          engineuser != null ? engineuser : globalConfig.getEngineuser(),
-          enginepass != null ? enginepass : globalConfig.getEnginepass().getPlainText(),
+          engineuser,
+          enginepass,
           isEngineverifyOverrride ? engineverify : globalConfig.getEngineverify(), globalConfig.getContainerImageId(),
           globalConfig.getContainerId(), globalConfig.getLocalVol(), globalConfig.getModulesVol(), globalConfig.getUseSudo());
       worker = new BuildWorker(run, workspace, launcher, listener, config);
@@ -395,7 +401,7 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
     return (DescriptorImpl) super.getDescriptor();
   }
 
-  @Symbol("sysdigSecure") // For Jenkins pipeline workflow. This lets pipeline refer to step using the defined identifier
+  @Symbol("sysdig") // For Jenkins pipeline workflow. This lets pipeline refer to step using the defined identifier
   @Extension // This indicates to Jenkins that this is an implementation of an extension point.
   public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
@@ -434,6 +440,7 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
     private String localVol;
     private String modulesVol;
     private boolean useSudo;
+	private String engineCredentialsId;
 
     // Upgrade case, you can never really remove these variables once they are introduced
     @Deprecated
@@ -455,7 +462,11 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
     public void setEngineurl(String engineurl) {
       this.engineurl = engineurl;
     }
-
+	
+    public void setEngineCredentialsId(String engineCredentialsId) {
+      this.engineCredentialsId = engineCredentialsId;
+    }
+	
     public void setEngineuser(String engineuser) {
       this.engineuser = engineuser;
     }
@@ -517,6 +528,10 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
 
     public String getEngineuser() {
       return engineuser;
+    }
+	
+	public String getEngineCredentialsId() {
+      return engineCredentialsId;
     }
 
     public Secret getEnginepass() {

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/AnchoreBuilder.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/AnchoreBuilder.java
@@ -304,7 +304,7 @@ public class AnchoreBuilder extends Builder implements SimpleBuildStep {
                   run,
                   Collections.<DomainRequirement>emptyList());
           if (null != creds) {
-              //This is to maintain backward compatibility with how the API layer fetching the information. This will be changed in the next version to use 
+              //This is to maintain backward compatibility with how the API layer is fetching the information. This will be changed in the next version to use 
               //the Authorization header instead.  
               engineuser = creds.getPassword().getPlainText();
               enginepass = "";

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/BuildConfig.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/BuildConfig.java
@@ -209,8 +209,6 @@ public class BuildConfig {
     if (enginemode.equals("anchoreengine")) {
       // Global or build properties
       consoleLog.logInfo("[build] engineurl: " + engineurl);
-      consoleLog.logInfo("[build] engineuser: " + engineuser);
-      consoleLog.logInfo("[build] enginepass: " + "****");
       consoleLog.logInfo("[build] engineverify: " + String.valueOf(engineverify));
 
       // Build properties

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/BuildWorker.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/BuildWorker.java
@@ -55,7 +55,7 @@ public class BuildWorker {
   private static final Logger LOG = Logger.getLogger(BuildWorker.class.getName());
 
   // TODO refactor
-  private static final String ANCHORE_BINARY = "anchore";
+  private static final String ANCHORE_BINARY = "sysdig";
   private static final String GATES_OUTPUT_PREFIX = "sysdig_secure_gates";
   private static final String CVE_LISTING_PREFIX = "sysdig_secure_security";
   private static final String QUERY_OUTPUT_PREFIX = "sysdig_secure_query_";

--- a/src/main/resources/com/sysdig/jenkins/plugins/sysdig/AnchoreBuilder/global.jelly
+++ b/src/main/resources/com/sysdig/jenkins/plugins/sysdig/AnchoreBuilder/global.jelly
@@ -1,16 +1,15 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
   <f:section title="Sysdig Secure Plugin  Mode">
 
-    inline="true" help="/plugin/sysdig-secure/help/help-AnchoreEngineMode.html">>
 
     <f:entry title="Engine URL" field="engineurl">
       <f:textbox name="engineurl" default="https://secure.sysdig.com/api/scanning/v1/anchore"/>
     </f:entry>
 
-    <f:entry title="Sysdig Secure API Token" field="engineuser">
-      <f:textbox name="engineuser" default=""/>
+    <f:entry title="Sysdig Secure API Credentials" field="engineCredentialsId">
+      <c:select/>
     </f:entry>
 
     <f:entry title="Verify SSL" field="engineverify">


### PR DESCRIPTION
Minor (and long awaited) change, to modify the way the plugin global credentials are being used. Instead of plain text, we now fetch the credentials from the credentials store, the same way as the per-job configuration is handled.   