### PR TITLE
feat: Some Inline Scanning improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To configure the Sysdig Secure plugin:
 
     ![Sysdig Token Configuration](docs/images/SysdigTokenConfiguration.png)
     
-6.  Configure the Sysdig Backend URL, `https://secure.sysdig.com` if you are using SaaS or your own if you are using an on-prem installation, and select the previously created credential.
+6.  Configure the Sysdig Backend URL, `https://api.sysdigcloud.com` if you are using SaaS or your own if you are using an on-prem installation, and select the previously created credential.
 
     Mark the Inline scanning option in case you have decided to use Inline scanning:
 
@@ -173,7 +173,7 @@ The table below describes each of the configuration options.
 The following is an example of executing the Sysdig Secure plugin as a Jenkinsfile step, modifying the default parameters
 
 ```
-sysdig bailOnFail: false, bailOnPluginFail: false, engineCredentialsId: 'sysdig-secure-api-credentials', engineRetries: '10', engineurl: 'https://secure.sysdig.com', inlineScanning: true, name: 'sysdig_secure_images'
+sysdig bailOnFail: false, bailOnPluginFail: false, engineCredentialsId: 'sysdig-secure-api-credentials', engineRetries: '10', engineurl: 'https://api.sysdigcloud.com', inlineScanning: true, name: 'sysdig_secure_images'
 ```
 
 # Plugin outputs

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder.java
@@ -163,7 +163,7 @@ public class SysdigBuilder extends Builder implements SimpleBuildStep {
     public static final boolean DEFAULT_BAIL_ON_PLUGIN_FAIL = true;
     public static final boolean DEFAULT_INLINE_SCANNING = false;
     public static final String EMPTY_STRING = "";
-    public static final String DEFAULT_ENGINE_URL = "https://secure.sysdig.com";
+    public static final String DEFAULT_ENGINE_URL = "https://api.sysdigcloud.com";
 
     // Global configuration
     private boolean debug;

--- a/src/main/resources/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder/global.jelly
+++ b/src/main/resources/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder/global.jelly
@@ -4,7 +4,7 @@
   <f:section title="Sysdig Secure Plugin Mode">
 
     <f:entry title="Engine URL" field="engineurl">
-      <f:textbox name="engineurl" default="https://secure.sysdig.com"/>
+      <f:textbox name="engineurl" default="https://api.sysdigcloud.com"/>
     </f:entry>
 
     <f:entry title="Sysdig Secure API Credentials" field="engineCredentialsId">


### PR DESCRIPTION
This PR improves 3 things in the Inline Scanning procedure:

1. Do not name the container that executes the Inline Scanning, as there could be other scanning processes in the same host. Also, auto-remove it after 1h if the scanning has failed to execute, for an exception or similar. The container will still be executed in background with a sleep, so no resources will be consumed by the container.
2. Update the URL to upload the metadata to the synchronous endpoint as is more reliable and does not suffer from the timeouts the asynchronous has. If the sync endpoint does not exist (404), fall back to the async one.
3. Use the anchore-engine image instead of the inline-scan one, so instead of downloading an image of 1GB, it downloads 100MB only.