### PR TITLE
fix: Add Guava dependency explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>sysdig-secure</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.2</version>
   <packaging>hpi</packaging>
   <name>Sysdig Secure Container Image Scanner Plugin</name>
   <description>Integrates Jenkins with the Sysdig Secure Image Scanner to scan OCI images</description>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
       <artifactId>jackson-annotations</artifactId>
       <version>2.10.3</version>
     </dependency>
+    <dependency> <!-- required by docker-java -->
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
+    </dependency>
   </dependencies>
 
 


### PR DESCRIPTION
This PR adds the guava dependency explicitly to solve this issue:

```
java.lang.ClassNotFoundException: com.google.common.io.BaseEncoding
	at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1387)
	at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1342)
	at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1089)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
Caused: java.lang.NoClassDefFoundError: com/google/common/io/BaseEncoding
	at com.github.dockerjava.core.exec.AbstrDockerCmdExec.registryAuth(AbstrDockerCmdExec.java:45)
	at com.github.dockerjava.core.exec.AbstrDockerCmdExec.resourceWithAuthConfig(AbstrDockerCmdExec.java:77)
	at com.github.dockerjava.core.exec.AbstrDockerCmdExec.resourceWithOptionalAuthConfig(AbstrDockerCmdExec.java:84)
	at com.github.dockerjava.core.exec.PullImageCmdExec.execute0(PullImageCmdExec.java:33)
	at com.github.dockerjava.core.exec.PullImageCmdExec.execute0(PullImageCmdExec.java:13)
	at com.github.dockerjava.core.exec.AbstrAsyncDockerCmdExec.execute(AbstrAsyncDockerCmdExec.java:56)
	at com.github.dockerjava.core.exec.AbstrAsyncDockerCmdExec.exec(AbstrAsyncDockerCmdExec.java:21)
	at com.github.dockerjava.core.exec.AbstrAsyncDockerCmdExec.exec(AbstrAsyncDockerCmdExec.java:12)
	at com.github.dockerjava.core.command.AbstrAsyncDockerCmd.exec(AbstrAsyncDockerCmd.java:21)
	at com.github.dockerjava.api.command.PullImageCmd.start(PullImageCmd.java:47)
	at com.sysdig.jenkins.plugins.sysdig.RemoteInlineScanningExecution.getDigestIDFromImage(RemoteInlineScanningExecution.java:146)
	at com.sysdig.jenkins.plugins.sysdig.RemoteInlineScanningExecution.scanImage(RemoteInlineScanningExecution.java:97)
	at com.sysdig.jenkins.plugins.sysdig.RemoteInlineScanningExecution.call(RemoteInlineScanningExecution.java:73)
	at com.sysdig.jenkins.plugins.sysdig.RemoteInlineScanningExecution.call(RemoteInlineScanningExecution.java:49)
	at hudson.remoting.LocalChannel.call(LocalChannel.java:46)
	at com.sysdig.jenkins.plugins.sysdig.BuildWorkerInline.scanImages(BuildWorkerInline.java:86)
	at com.sysdig.jenkins.plugins.sysdig.SysdigBuilderExecutor.<init>(SysdigBuilderExecutor.java:77)
	at com.sysdig.jenkins.plugins.sysdig.SysdigBuilder.perform(SysdigBuilder.java:147)
	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:123)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:116)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:71)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```