### PR TITLE
Fix a stacktrace that is printed even if log debug is disabled

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/log/ConsoleLog.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/log/ConsoleLog.java
@@ -45,7 +45,7 @@ public class ConsoleLog implements SysdigLogger, Serializable {
   @Override
   public void logDebug(String msg, Throwable t) {
     logDebug(msg);
-    if (null != t) {
+    if (enableDebug && null != t) {
       t.printStackTrace(getLogger());
     }
   }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/log/SysdigLogger.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/log/SysdigLogger.java
@@ -1,7 +1,5 @@
 package com.sysdig.jenkins.plugins.sysdig.log;
 
-import java.io.PrintStream;
-
 public interface SysdigLogger {
   void logDebug(String msg);
 


### PR DESCRIPTION
The logDebug(msg,throwable) method was printing the stacktrace even if DEBUG option was disabled, causing the logs to show a captured error for backend scanning when there where retries.