### PR TITLE
feat: support DOCKER_HOST for dind scenarios

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,12 @@
     <dependency>
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.7</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-transport-httpclient5</artifactId>
+      <version>3.2.7</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -106,6 +111,11 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>19.0</version>
+    </dependency>
+    <dependency> <!-- required by docker-java-transport-httpclient5 -->
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.13</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/ContainerRunnerFactory.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/ContainerRunnerFactory.java
@@ -1,7 +1,8 @@
 package com.sysdig.jenkins.plugins.sysdig.containerrunner;
 
 import com.sysdig.jenkins.plugins.sysdig.log.SysdigLogger;
+import hudson.EnvVars;
 
 public interface ContainerRunnerFactory {
-  ContainerRunner getContainerRunner(SysdigLogger logger);
+  ContainerRunner getContainerRunner(SysdigLogger logger, EnvVars currentEnv);
 }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientContainerFactory.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientContainerFactory.java
@@ -1,12 +1,13 @@
 package com.sysdig.jenkins.plugins.sysdig.containerrunner;
 
 import com.sysdig.jenkins.plugins.sysdig.log.SysdigLogger;
+import hudson.EnvVars;
 
 import java.io.Serializable;
 
 public class DockerClientContainerFactory implements ContainerRunnerFactory, Serializable {
   @Override
-  public ContainerRunner getContainerRunner(SysdigLogger logger) {
-    return new DockerClientRunner(logger);
+  public ContainerRunner getContainerRunner(SysdigLogger logger, EnvVars currentEnv) {
+    return new DockerClientRunner(logger, currentEnv);
   }
 }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
@@ -76,7 +76,7 @@ public class InlineScannerRemoteExecutor implements Callable<String, Exception>,
   @Override
 
   public String call() throws InterruptedException {
-    ContainerRunner containerRunner = containerRunnerFactory.getContainerRunner(logger);
+    ContainerRunner containerRunner = containerRunnerFactory.getContainerRunner(logger, this.nodeEnvVars);
 
     List<String> args = new ArrayList<>();
     args.add(SCAN_COMMAND);

--- a/src/test/java/FullWorkflowTests.java
+++ b/src/test/java/FullWorkflowTests.java
@@ -52,7 +52,7 @@ public class FullWorkflowTests {
 
     ContainerRunner containerRunner = mock(ContainerRunner.class);
     containerRunnerFactory = mock (ContainerRunnerFactory.class);
-    when(containerRunnerFactory.getContainerRunner(any())).thenReturn(containerRunner);
+    when(containerRunnerFactory.getContainerRunner(any(), any())).thenReturn(containerRunner);
 
     InlineScannerRemoteExecutor.setContainerRunnerFactory(containerRunnerFactory);
     BackendScanner.setBackendScanningClientFactory(backendClientFactory);

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
@@ -54,7 +54,7 @@ public class InlineScannerRemoteExecutorTests {
 
     containerRunner = mock(ContainerRunner.class);
     ContainerRunnerFactory containerRunnerFactory = mock (ContainerRunnerFactory.class);
-    when(containerRunnerFactory.getContainerRunner(any())).thenReturn(containerRunner);
+    when(containerRunnerFactory.getContainerRunner(any(), any())).thenReturn(containerRunner);
 
     nodeEnvVars = new EnvVars();
     logger = mock(SysdigLogger.class);


### PR DESCRIPTION
* Bump docker-java to 3.2.7
* Change docker-java transport to Apache HttpClient 5, and honor the DOCKER_HOST, DOCKER_TLS_VERIFY and DOCKER_CERT_PATH variables to be able to connect to docker via tcp:// and using TLS.