### PR TITLE
Fix inline-scan 2.3 logs and image override

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
@@ -111,7 +111,7 @@ public class InlineScannerRemoteExecutor implements Callable<String, Exception>,
     logger.logDebug("Creating container with environment: " + envVars.toString());
     logger.logDebug("Bind mounts: " + bindMounts.toString());
 
-    Container inlineScanContainer = containerRunner.createContainer(INLINE_SCAN_IMAGE, Collections.singletonList(DUMMY_ENTRYPOINT), null, envVars, bindMounts);
+    Container inlineScanContainer = containerRunner.createContainer(nodeEnvVars.get("SYSDIG_OVERRIDE_INLINE_SCAN_IMAGE", INLINE_SCAN_IMAGE), Collections.singletonList(DUMMY_ENTRYPOINT), null, envVars, bindMounts);
     final StringBuilder builder = new StringBuilder();
 
     try {

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
@@ -34,9 +34,9 @@ public class InlineScannerRemoteExecutor implements Callable<String, Exception>,
 
   private static final String INLINE_SCAN_IMAGE = "quay.io/sysdig/secure-inline-scan:2";
   private static final String DUMMY_ENTRYPOINT = "cat";
-  private static final String[] MKDIR_COMMAND = new String[]{"mkdir", "/tmp/sysdig-inline-scan"};
-  private static final String[] TOUCH_COMMAND = new String[]{"touch", "/tmp/sysdig-inline-scan/info.log"};
-  private static final String[] TAIL_COMMAND = new String[]{"tail", "-f", "/tmp/sysdig-inline-scan/info.log"};
+  private static final String[] MKDIR_COMMAND = new String[]{"mkdir", "-p", "/tmp/sysdig-inline-scan/logs"};
+  private static final String[] TOUCH_COMMAND = new String[]{"touch", "/tmp/sysdig-inline-scan/logs/info.log"};
+  private static final String[] TAIL_COMMAND = new String[]{"tail", "-f", "/tmp/sysdig-inline-scan/logs/info.log"};
   private static final String SCAN_COMMAND = "/sysdig-inline-scan.sh";
   private static final String[] SCAN_ARGS = new String[] {
     "--storage-type=docker-daemon",

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
@@ -345,4 +345,21 @@ public class InlineScannerRemoteExecutorTests {
       argThat(env -> env.contains("no_proxy=1.2.3.4,5.6.7.8")),
       any());
   }
+
+  @Test
+  public void inlineScanImageCanBeOverridden() throws Exception {
+    // Given
+    nodeEnvVars.put("SYSDIG_OVERRIDE_INLINE_SCAN_IMAGE", "my-repo/my-custom-image:foo");
+
+    // When
+    scannerRemoteExecutor.call();
+
+    // Then
+    verify(containerRunner, times(1)).createContainer(
+      eq("my-repo/my-custom-image:foo"),
+      argThat(args -> args.contains("cat")),
+      any(),
+      any(),
+      any());
+  }
 }


### PR DESCRIPTION
New inline-scan 2.3 changed the path where the info.log is located, so the real-time output of the container during the execution was missing (although the scan was performed correctly, as the final JSON output is still processed).

This PR uses the new path, and also allows overriding the container image name via an environment variable, which can be used to pin old version of the inline-scan container and revert to an older version in case there are compatibility issues in new releases. It also allows use in air-gapped environments.