### PR TITLE
fix: accept scan report even if there is a digest mismatch

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/Scanner.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/Scanner.java
@@ -9,6 +9,7 @@ import net.sf.json.JSONObject;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 
 public abstract class Scanner {
@@ -54,10 +55,20 @@ public abstract class Scanner {
   }
 
   private ImageScanningResult buildImageScanningResult(JSONArray scanReport, JSONObject vulnsReport, String imageDigest, String tag) throws AbortException {
-    JSONObject tagEvalObj = JSONObject.fromObject(scanReport.get(0)).getJSONObject(imageDigest);
+    JSONObject reportDigests = JSONObject.fromObject(scanReport.get(0));
+    JSONObject firstReport = null;
+    for (Object key : reportDigests.keySet()) {
+      firstReport = reportDigests.getJSONObject((String) key);
+      break;
+    }
+
+    if (firstReport == null || firstReport.size() < 1) {
+      throw new AbortException(String.format("Failed to analyze %s due to missing digest eval records in sysdig-secure-engine policy evaluation response", tag));
+    }
+
     JSONArray tagEvals = null;
-    for (Object key : tagEvalObj.keySet()) {
-      tagEvals = tagEvalObj.getJSONArray((String) key);
+    for (Object key : firstReport.keySet()) {
+      tagEvals = firstReport.getJSONArray((String) key);
       break;
     }
 

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/ScannerTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/ScannerTests.java
@@ -1,11 +1,144 @@
 package com.sysdig.jenkins.plugins.sysdig.scanner;
 
+import com.sysdig.jenkins.plugins.sysdig.BuildConfig;
+import com.sysdig.jenkins.plugins.sysdig.log.SysdigLogger;
+import hudson.AbortException;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+import static org.junit.Assert.*;
+
 public class ScannerTests {
 
-  //TODO: Test the parent Scanner class that contains the parsing of the JSON into ImageScanningResult
+  class MockScanner extends Scanner {
+    private Map<String, ImageScanningSubmission> submissions;
+    private Map<String, JSONArray> gateResults;
+    private Map<String, JSONObject> vulnsReport;
 
-  //TODO: Test scan multiple images and collect the results (scanner.scanImages)
+    public MockScanner(BuildConfig config, SysdigLogger logger) {
+      super(config, logger);
+      this.submissions = new HashMap<>();
+      this.gateResults = new HashMap<>();
+      this.vulnsReport = new HashMap<>();
+    }
 
-  //TODO: Error if dockerfile specified and it does not exist
+    @Override
+    public ImageScanningSubmission scanImage(String imageTag, String dockerfile) throws AbortException {
+      return this.submissions.get(imageTag);
+    }
+
+    @Override
+    public JSONArray getGateResults(ImageScanningSubmission submission) throws AbortException {
+      return this.gateResults.get(submission.getTag());
+    }
+
+    @Override
+    public JSONObject getVulnsReport(ImageScanningSubmission submission) throws AbortException {
+      return this.vulnsReport.get(submission.getTag());
+    }
+
+    public void setSubmission(String imageTag, ImageScanningSubmission submission) {
+      this.submissions.put(imageTag, submission);
+    }
+
+    public void setGateResults(String imageTag, JSONArray gateResults) {
+      this.gateResults.put(imageTag, gateResults);
+    }
+
+    public void setVulnsReport(String imageTag, JSONObject vulnsReport) {
+      this.vulnsReport.put(imageTag, vulnsReport);
+    }
+
+  }
+
+  MockScanner scanner;
+
+  @Before
+  public void BeforeEach() {
+    BuildConfig config = mock(BuildConfig.class);
+    PrintStream logger = mock(PrintStream.class);
+    this.scanner = new MockScanner(config, mock(SysdigLogger.class));
+  }
+
+  @Test
+  public void testParsingReports() throws AbortException {
+    Map<String, String> imagesAndDockerfiles = new HashMap<>();
+    imagesAndDockerfiles.put("image:tag", null);
+
+    scanner.setSubmission("image:tag", new ImageScanningSubmission("image:tag", "some-digest"));
+    scanner.setGateResults("image:tag", JSONArray.fromObject("[{\"some-digest\": {\"random:image-tag\" : [{\"status\": \"foo\", \"detail\" : {\"result\": {\"result\": { \"foo\": \"bar\"}}}}]}}]"));
+    scanner.setVulnsReport("image:tag", JSONObject.fromObject("{\"vulns\": \"blahblah\"}"));
+
+    ArrayList<ImageScanningResult> results = scanner.scanImages(imagesAndDockerfiles);
+
+    assertEquals("foo", results.get(0).getEvalStatus());
+    assertEquals(JSONObject.fromObject("{\"foo\": \"bar\"}"), results.get(0).getGateResult());
+    assertEquals(JSONObject.fromObject("{\"vulns\": \"blahblah\"}"), results.get(0).getVulnerabilityReport());
+  }
+
+  @Test
+  public void testDigestMismatchInReportIsIgnored() throws AbortException {
+    Map<String, String> imagesAndDockerfiles = new HashMap<>();
+    imagesAndDockerfiles.put("image:tag", null);
+
+    scanner.setSubmission("image:tag", new ImageScanningSubmission("image:tag", "other-digest"));
+    scanner.setGateResults("image:tag", JSONArray.fromObject("[{\"some-digest\": {\"random:image-tag\" : [{\"status\": \"foo\", \"detail\" : {\"result\": {\"result\": { \"foo\": \"bar\"}}}}]}}]"));
+    scanner.setVulnsReport("image:tag", JSONObject.fromObject("{\"vulns\": \"blahblah\"}"));
+
+    ArrayList<ImageScanningResult> results = scanner.scanImages(imagesAndDockerfiles);
+
+    assertEquals("foo", results.get(0).getEvalStatus());
+  }
+
+  @Test
+  public void testMultipleImages() throws AbortException {
+    Map<String, String> imagesAndDockerfiles = new HashMap<>();
+    imagesAndDockerfiles.put("image1:tag1", null);
+    imagesAndDockerfiles.put("image2:tag2", null);
+
+    scanner.setSubmission("image1:tag1", new ImageScanningSubmission("image1:tag1", "some-digest"));
+    scanner.setGateResults("image1:tag1", JSONArray.fromObject("[{\"some-digest\": {\"random:image-tag\" : [{\"status\": \"foo1\", \"detail\" : {\"result\": {\"result\": { \"foo\": \"bar\"}}}}]}}]"));
+    scanner.setVulnsReport("image1:tag1", JSONObject.fromObject("{\"vulns\": \"blahblah1\"}"));
+
+    scanner.setSubmission("image2:tag2", new ImageScanningSubmission("image2:tag2", "some-digest"));
+    scanner.setGateResults("image2:tag2", JSONArray.fromObject("[{\"some-digest\": {\"random:image-tag\" : [{\"status\": \"foo2\", \"detail\" : {\"result\": {\"result\": { \"foo\": \"bar\"}}}}]}}]"));
+    scanner.setVulnsReport("image2:tag2", JSONObject.fromObject("{\"vulns\": \"blahblah2\"}"));
+
+    ArrayList<ImageScanningResult> results = scanner.scanImages(imagesAndDockerfiles);
+
+    assertEquals(2, results.size());
+    ImageScanningResult one = results.get(0);
+    ImageScanningResult two = results.get(1);
+    assertNotEquals(one, two);
+    results.forEach(entry -> {
+      if (entry.getTag() == "image1:tag1") {
+        assertEquals("foo1", entry.getEvalStatus());
+      } else {
+        assertEquals("foo2", entry.getEvalStatus());
+      }
+    });
+  }
+
+  @Test
+  public void testNonExistingDOckerfile() throws AbortException {
+    Map<String, String> imagesAndDockerfiles = new HashMap<>();
+    imagesAndDockerfiles.put("image:tag", "non-existing-Dockerfile");
+
+    // When
+    AbortException thrown = assertThrows(
+      AbortException.class,
+      () -> scanner.scanImages(imagesAndDockerfiles));
+
+    assertEquals("Dockerfile 'non-existing-Dockerfile' does not exist", thrown.getMessage());
+  }
 
 }


### PR DESCRIPTION
There are some edge cases where the digest key in the scan report does not match the local digest detected by the inline scanner. The plugin should ignore the digest in the report, if it doesn't match the image digest, and just parse the results.

https://sysdig.atlassian.net/browse/SSPROD-6906
https://sysdig.atlassian.net/browse/ESC-703

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

