### PR TITLE
fix: copy Dockerfile inside container instead of bind mount

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/Container.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/Container.java
@@ -9,4 +9,5 @@ public interface Container {
   void exec(List<String> args, List<String> envVars, Consumer<String> stdoutCallback, Consumer<String> stderrCallback) throws InterruptedException;
   void execAsync(List<String> args, List<String> envVars, Consumer<String> stdoutCallback, Consumer<String> stderrCallback);
   void stop(int timeout);
+  void copy(String source, String destinationFolder);
 }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientContainer.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientContainer.java
@@ -93,6 +93,14 @@ public class DockerClientContainer implements Container {
   }
 
   @Override
+  public void copy(String source, String destinationFolder) {
+    dockerClient.copyArchiveToContainerCmd(this.containerId)
+      .withHostResource(source)
+      .withRemotePath(destinationFolder)
+      .exec();
+  }
+
+  @Override
   public void stop(int timeout) {
     dockerClient.stopContainerCmd(this.containerId)
       .withTimeout(timeout)

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientRunner.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientRunner.java
@@ -9,13 +9,11 @@ import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
-import com.github.dockerjava.transport.DockerHttpClient;
 import com.sysdig.jenkins.plugins.sysdig.log.SysdigLogger;
 import hudson.EnvVars;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 public class DockerClientRunner implements ContainerRunner {
 

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
@@ -249,22 +249,24 @@ public class InlineScannerRemoteExecutorTests {
     scannerRemoteExecutor.call();
 
     // Then
-    verify(container, times(1)).exec(argThat(args -> args.contains("--dockerfile=/tmp/Dockerfile")), isNull(), any(), any());
+    verify(container, times(1)).exec(argThat(args -> args.contains("--dockerfile=/tmp/foo-dockerfile")), isNull(), any(), any());
   }
 
   @Test
-  public void dockerfileIsMountedAtTmp() throws Exception {
-    scannerRemoteExecutor = new InlineScannerRemoteExecutor(IMAGE_TO_SCAN, "/tmp/foo-dockerfile", config, logger, nodeEnvVars);
+  public void dockerfileIsCopiedInsideContainer() throws Exception {
+    scannerRemoteExecutor = new InlineScannerRemoteExecutor(IMAGE_TO_SCAN, "/some/path/foo-dockerfile", config, logger, nodeEnvVars);
 
     // When
     scannerRemoteExecutor.call();
+
+    verify(container, times(1)).copy("/some/path/foo-dockerfile", "/tmp/");
 
     verify(containerRunner, times(1)).createContainer(
       eq(SCAN_IMAGE),
       any(),
       any(),
       any(),
-      argThat(arg -> arg.contains("/tmp/foo-dockerfile:/tmp/Dockerfile")));
+      any());
   }
 
 


### PR DESCRIPTION
When providing a Dockerfile, it is bind mounted into /tmp/Dockerfile in the inline-scan container. This doesn't work if the docker daemon is not running in the agent, but in a remote host (for example, if we are mounting the docker.sock in the agent).

Instead of mounting the file, copy it inside the container.

https://sysdig.atlassian.net/browse/SSPROD-6237

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
