### PR TITLE
Fix bailOnFail being ignored if not used along bailOnPluginFail

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/SysdigBuilderExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/SysdigBuilderExecutor.java
@@ -91,7 +91,7 @@ public class SysdigBuilderExecutor {
     /* Evaluate result of step based on gate action */
     if (null == finalAction) {
       logger.logInfo("Marking Sysdig Secure Container Image Scanner step as successful, no final result");
-    } else if ((config.getBailOnFail() || builder.getBailOnPluginFail()) && Util.GATE_ACTION.FAIL.equals(finalAction)) {
+    } else if ((config.getBailOnFail() || builder.getBailOnFail()) && Util.GATE_ACTION.FAIL.equals(finalAction)) {
       logger.logWarn("Failing Sysdig Secure Container Image Scanner Plugin step due to final result " + finalAction);
       throw new AbortException("Failing Sysdig Secure Container Image Scanner Plugin step due to final result " + finalAction);
     } else {


### PR DESCRIPTION
The bailOnFail option was ignored if bailOnPluginFail was not unchecked. Fix this condition.

https://sysdig.atlassian.net/browse/SSPROD-7303

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira 
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

