### PR TITLE
Use run.getEnvironment to fetch env vars from EnvironmentContributors

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder.java
@@ -181,6 +181,9 @@ public class SysdigBuilder extends Builder implements SimpleBuildStep, SysdigSca
       envVars.putAll(computer.buildEnvironment(listener));
     }
 
+    EnvVars buildEnvVars = run.getEnvironment(listener);
+    envVars.putAll(buildEnvVars);
+
     perform(run, workspace, launcher, listener, envVars);
   }
 


### PR DESCRIPTION
The Freestyle job step was not correctly honoring environment variables set by the InjectEnv plugin.

Use run.getBuildEnvironment() method to get the variables from all EnvironmentContributors and have the expected behavior.

(cherry picked from commit bc1977824c1425d6cdbf1170e4aa321b99e0a605)
