### PR TITLE
fix: customize connection timeout and allow ping [SSPROD-11248]

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ Connection to the Docker daemon uses the FIFO socket at /var/run/docker.sock by 
 * DOCKER_TLS_VERIFY: When set Docker uses TLS and verifies the remote
 * DOCKER_CERT_PATH: The location of your authentication keys
 
+Additional environment variables can be set to apply a more customized behaviour:
+
+* DOCKER_CONNECTION_TIMEOUT: The time (in seconds) the docker client will wait for connection to be established before a timeout
+* DOCKER_RESPONSE_TIMEOUT: The time (in seconds) the docker client will wait for a response before a timeout. (Default: 10 minutes)
+* DOCKER_CMD_EXEC_PING_DELAY: The delay (in seconds) between ping requests made by the docker client during the scan-command execution. (Default: no ping)
+
 See [Docker environment variables documentation](https://docs.docker.com/engine/reference/commandline/cli/#environment-variables) for more information.
 
 Environment variables must be defined in **the worker node**. See *Configuring environment variables in workers* section.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Connection to the Docker daemon uses the FIFO socket at /var/run/docker.sock by 
 
 Additional environment variables can be set to apply a more customized behaviour:
 
-* DOCKER_CONNECTION_TIMEOUT: The time (in seconds) the docker client will wait for connection to be established before a timeout
+* DOCKER_CONNECTION_TIMEOUT: The time (in seconds) the docker client will wait for connection to be established before a timeout. (Default: 3 minutes)
 * DOCKER_RESPONSE_TIMEOUT: The time (in seconds) the docker client will wait for a response before a timeout. (Default: 10 minutes)
 * DOCKER_CMD_EXEC_PING_DELAY: The delay (in seconds) between ping requests made by the docker client during the scan-command execution. (Default: no ping)
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,12 @@
     <dependency>
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java</artifactId>
-      <version>3.2.12</version>
+      <version>3.2.13</version>
     </dependency>
     <dependency>
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java-transport-httpclient5</artifactId>
-      <version>3.2.12</version>
+      <version>3.2.13</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -194,7 +194,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.9</version>
+        <version>3.12.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,7 @@
         <artifactId>maven-hpi-plugin</artifactId>
         <configuration>
           <minimumJavaVersion>1.8</minimumJavaVersion>
+          <pluginFirstClassLoader>false</pluginFirstClassLoader>
           <webResources>
             <webResource>
               <directory>${project.build.directory}/external-resources</directory>

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/Container.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/Container.java
@@ -10,4 +10,5 @@ public interface Container {
   void execAsync(List<String> args, List<String> envVars, Consumer<String> stdoutCallback, Consumer<String> stderrCallback);
   void stop(int timeout);
   void copy(String source, String destinationFolder);
+  void ping();
 }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientContainer.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientContainer.java
@@ -110,4 +110,10 @@ public class DockerClientContainer implements Container {
     .withForce(true)
     .exec();
   }
+
+  @Override
+  public void ping() {
+    dockerClient.pingCmd().exec();
+  }
+
 }


### PR DESCRIPTION
 - Updates `docker-java` and relative dependencies to latest version
 - Do scheduled pings during the scanning command execution, by specifying the  `DOCKER_CMD_EXEC_PING_DELAY` env-var
 - Adds support for both a connection and response timeout, each with a corresponding env-var
 - Updates README