### PR TITLE
Add explicit dependency to apache.commons.lang3 for docker-java-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
       <artifactId>guava</artifactId>
       <version>19.0</version>
     </dependency>
+    <dependency> <!-- required by docker-java-core -->
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+    </dependency>
     <dependency> <!-- required by docker-java-transport-httpclient5 -->
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
@@ -195,7 +200,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.12.0</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Trying to fix the issue:

```
...
2022-05-03T21:46:44.474 INFO   SysdigSecurePlugin Completed Sysdig Secure Container Image Scanner step
FATAL: org/apache/commons/lang3/BooleanUtils
java.lang.NoClassDefFoundError: org/apache/commons/lang3/BooleanUtils
	at com.github.dockerjava.core.DefaultDockerClientConfig$Builder.build(DefaultDockerClientConfig.java:438)
	at com.sysdig.jenkins.plugins.sysdig.containerrunner.DockerClientRunner.<init>(DockerClientRunner.java:43)
	at com.sysdig.jenkins.plugins.sysdig.containerrunner.DockerClientContainerFactory.getContainerRunner(DockerClientContainerFactory.java:11)
	at com.sysdig.jenkins.plugins.sysdig.scanner.InlineScannerRemoteExecutor.call(InlineScannerRemoteExecutor.java:87)
	at com.sysdig.jenkins.plugins.sysdig.scanner.InlineScannerRemoteExecutor.call(InlineScannerRemoteExecutor.java:34)
	at hudson.FilePath.act(FilePath.java:1288)
	at com.sysdig.jenkins.plugins.sysdig.scanner.InlineScanner.scanImage(InlineScanner.java:64)
	at com.sysdig.jenkins.plugins.sysdig.scanner.Scanner.scanImages(Scanner.java:36)
	at com.sysdig.jenkins.plugins.sysdig.BuildWorker.scanAndBuildReports(BuildWorker.java:102)
	at com.sysdig.jenkins.plugins.sysdig.SysdigBuilderExecutor.<init>(SysdigBuilderExecutor.java:69)
	at com.sysdig.jenkins.plugins.sysdig.SysdigBuilder.perform(SysdigBuilder.java:191)
	at com.sysdig.jenkins.plugins.sysdig.SysdigBuilder.perform(SysdigBuilder.java:187)
	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:123)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:79)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:814)
	at hudson.model.Build$BuildExecution.build(Build.java:199)
	at hudson.model.Build$BuildExecution.doRun(Build.java:164)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:522)
	at hudson.model.Run.execute(Run.java:1896)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:44)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:442)
```

by making the dependency to apache.commons lang3 explicit and removing the "test" scope.

