### PR TITLE
Fix bug - env variable for Daemon socket path was ignored

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/Util.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/Util.java
@@ -15,23 +15,27 @@ limitations under the License.
 */
 package com.sysdig.jenkins.plugins.sysdig;
 
-import java.nio.file.Paths;
+
+import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
 
 public class Util {
 
   public enum GATE_ACTION {PASS, FAIL}
   public enum GATE_SUMMARY_COLUMN {Repo_Tag, Stop_Actions, Warn_Actions, Go_Actions, Final_Action}
 
-  public static boolean isValidLocalPath(String path) {
+  public static boolean isValidLocalExistingFile(String path) {
     try {
       Paths.get(path);
     } catch (InvalidPathException | NullPointerException ex) {
       return false;
     }
-    if (path.length()>0 && path.substring(0, 1).equals("/")){
-      return true;
+    File f = new File(path);
+    if (!path.startsWith("/") || !f.isFile()){
+      return false;
     }
-    return false;
+    return true;
   }
 }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/Util.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/Util.java
@@ -15,11 +15,23 @@ limitations under the License.
 */
 package com.sysdig.jenkins.plugins.sysdig;
 
-import com.google.common.base.Splitter;
-import java.util.regex.Pattern;
+import java.nio.file.Paths;
+import java.nio.file.InvalidPathException;
 
 public class Util {
 
   public enum GATE_ACTION {PASS, FAIL}
   public enum GATE_SUMMARY_COLUMN {Repo_Tag, Stop_Actions, Warn_Actions, Go_Actions, Final_Action}
+
+  public static boolean isValidLocalPath(String path) {
+    try {
+      Paths.get(path);
+    } catch (InvalidPathException | NullPointerException ex) {
+      return false;
+    }
+    if (path.length()>0 && path.substring(0, 1).equals("/")){
+      return true;
+    }
+    return false;
+  }
 }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/Util.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/Util.java
@@ -26,14 +26,14 @@ public class Util {
   public enum GATE_ACTION {PASS, FAIL}
   public enum GATE_SUMMARY_COLUMN {Repo_Tag, Stop_Actions, Warn_Actions, Go_Actions, Final_Action}
 
-  public static boolean isValidLocalExistingFile(String path) {
+  public static boolean isExistingFile(String path) {
     try {
       Paths.get(path);
     } catch (InvalidPathException | NullPointerException ex) {
       return false;
     }
     File f = new File(path);
-    if (!path.startsWith("/") || !f.isFile()){
+    if (!f.isFile()){
       return false;
     }
     return true;

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/ContainerRunnerFactory.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/ContainerRunnerFactory.java
@@ -4,5 +4,5 @@ import com.sysdig.jenkins.plugins.sysdig.log.SysdigLogger;
 import hudson.EnvVars;
 
 public interface ContainerRunnerFactory {
-  ContainerRunner getContainerRunner(SysdigLogger logger, EnvVars currentEnv);
+  ContainerRunner getContainerRunner(SysdigLogger logger, EnvVars currentEnv, String dockerHost);
 }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientContainerFactory.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientContainerFactory.java
@@ -7,7 +7,7 @@ import java.io.Serializable;
 
 public class DockerClientContainerFactory implements ContainerRunnerFactory, Serializable {
   @Override
-  public ContainerRunner getContainerRunner(SysdigLogger logger, EnvVars currentEnv) {
-    return new DockerClientRunner(logger, currentEnv);
+  public ContainerRunner getContainerRunner(SysdigLogger logger, EnvVars currentEnv, String dockerHost) {
+    return new DockerClientRunner(logger, currentEnv, dockerHost);
   }
 }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientRunner.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/containerrunner/DockerClientRunner.java
@@ -25,11 +25,11 @@ public class DockerClientRunner implements ContainerRunner {
   private final DockerClient dockerClient;
   private final SysdigLogger logger;
 
-  public DockerClientRunner(SysdigLogger logger, EnvVars currentEnv) {
+  public DockerClientRunner(SysdigLogger logger, EnvVars currentEnv, String dockerHost) {
 
     DefaultDockerClientConfig.Builder configBuilder = DefaultDockerClientConfig.createDefaultConfigBuilder();
-    if (currentEnv.get("DOCKER_HOST") != null) {
-      configBuilder.withDockerHost(currentEnv.get("DOCKER_HOST"));
+    if (dockerHost != null) {
+      configBuilder.withDockerHost(dockerHost);
     }
 
     if (currentEnv.get("DOCKER_TLS_VERIFY") != null) {

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
@@ -93,10 +93,14 @@ public class InlineScannerRemoteExecutor implements Callable<String, Exception>,
     // see https://github.com/jenkinsci/sysdig-secure-plugin/pull/55 discussion
     if (envVars.containsKey("DOCKER_HOST")) {
       String candidateVolumeHostPath = envVars.get("DOCKER_HOST");
-      if (Util.isValidLocalExistingFile(candidateVolumeHostPath)) {
-        bindMounts.add(candidateVolumeHostPath + ":" + DEFAULT_DOCKER_VOLUME);
-      } else {
+      if (!candidateVolumeHostPath.startsWith("/")){
         dockerVolumeInContainer = candidateVolumeHostPath;
+      } else {
+        if (Util.isExistingFile(candidateVolumeHostPath)) {
+          bindMounts.add(candidateVolumeHostPath + ":" + DEFAULT_DOCKER_VOLUME);
+        } else {
+          throw new AbortException("Daemon socket '" + candidateVolumeHostPath + "' does not exist");
+        }
       }
     } else {
       bindMounts.add(DEFAULT_DOCKER_VOLUME + ":" + DEFAULT_DOCKER_VOLUME);

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
@@ -28,6 +28,7 @@ import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.remoting.Callable;
 import org.jenkinsci.remoting.RoleChecker;
+import org.apache.commons.lang.SystemUtils;
 
 import java.io.*;
 import java.util.*;
@@ -93,11 +94,11 @@ public class InlineScannerRemoteExecutor implements Callable<String, Exception>,
     // see https://github.com/jenkinsci/sysdig-secure-plugin/pull/55 discussion
     if (envVars.containsKey("DOCKER_HOST")) {
       String candidateVolumeHostPath = envVars.get("DOCKER_HOST");
-      if (!candidateVolumeHostPath.startsWith("/")){
-        dockerVolumeInContainer = candidateVolumeHostPath;
+      if (Util.isExistingFile(candidateVolumeHostPath)) {
+        bindMounts.add(candidateVolumeHostPath + ":" + DEFAULT_DOCKER_VOLUME);
       } else {
-        if (Util.isExistingFile(candidateVolumeHostPath)) {
-          bindMounts.add(candidateVolumeHostPath + ":" + DEFAULT_DOCKER_VOLUME);
+          if (!candidateVolumeHostPath.startsWith("/")){
+          dockerVolumeInContainer = candidateVolumeHostPath;
         } else {
           throw new AbortException("Daemon socket '" + candidateVolumeHostPath + "' does not exist");
         }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
@@ -108,7 +108,8 @@ public class InlineScannerRemoteExecutor implements Callable<String, Exception>,
     addProxyVars(envVars, containerEnvVars, logger);
 
     List<String> bindMounts = new ArrayList<>();
-    bindMounts.add("/var/run/docker.sock:/var/run/docker.sock");
+    String daemonSocket = envVars.get("DOCKER_HOST", "/var/run/docker.sock");
+    bindMounts.add(daemonSocket + ":/var/run/docker.sock");
 
     logger.logDebug("System environment: " + System.getenv().toString());
     logger.logDebug("Final environment: " + envVars);

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
@@ -93,7 +93,7 @@ public class InlineScannerRemoteExecutor implements Callable<String, Exception>,
     // see https://github.com/jenkinsci/sysdig-secure-plugin/pull/55 discussion
     if (envVars.containsKey("DOCKER_HOST")) {
       String candidateVolumeHostPath = envVars.get("DOCKER_HOST");
-      if (Util.isValidLocalPath(candidateVolumeHostPath)) {
+      if (Util.isValidLocalExistingFile(candidateVolumeHostPath)) {
         bindMounts.add(candidateVolumeHostPath + ":" + DEFAULT_DOCKER_VOLUME);
       } else {
         dockerVolumeInContainer = candidateVolumeHostPath;

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
@@ -98,9 +98,9 @@ public class InlineScannerRemoteExecutor implements Callable<String, Exception>,
         bindMounts.add(candidateVolumeHostPath + ":" + DEFAULT_DOCKER_VOLUME);
       } else {
           if (!candidateVolumeHostPath.startsWith("/")){
-          dockerVolumeInContainer = candidateVolumeHostPath;
+            dockerVolumeInContainer = candidateVolumeHostPath;
         } else {
-          throw new AbortException("Daemon socket '" + candidateVolumeHostPath + "' does not exist");
+            throw new AbortException("Daemon socket '" + candidateVolumeHostPath + "' does not exist");
         }
       }
     } else {

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutor.java
@@ -260,6 +260,4 @@ public class InlineScannerRemoteExecutor implements Callable<String, Exception>,
       logger.logDebug(line);
     }
   }
-
-
 }

--- a/src/test/java/FullWorkflowTests.java
+++ b/src/test/java/FullWorkflowTests.java
@@ -50,7 +50,7 @@ public class FullWorkflowTests {
 
     ContainerRunner containerRunner = mock(ContainerRunner.class);
     ContainerRunnerFactory containerRunnerFactory = mock (ContainerRunnerFactory.class);
-    when(containerRunnerFactory.getContainerRunner(any(), any())).thenReturn(containerRunner);
+    when(containerRunnerFactory.getContainerRunner(any(), any(), any())).thenReturn(containerRunner);
 
     InlineScannerRemoteExecutor.setContainerRunnerFactory(containerRunnerFactory);
     BackendScanner.setBackendScanningClientFactory(backendClientFactory);

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
@@ -13,6 +13,7 @@ import org.junit.*;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
+import org.apache.commons.lang.SystemUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -230,7 +231,10 @@ public class InlineScannerRemoteExecutorTests {
 
     nodeEnvVars.override("DOCKER_HOST", customVolumePath);
 
-    assertThrows(AbortException.class, () -> scannerRemoteExecutor.call());
+    if (!SystemUtils.IS_OS_WINDOWS) {
+      assertThrows(AbortException.class, () -> scannerRemoteExecutor.call());
+    }
+
   }
 
 

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
@@ -205,7 +205,7 @@ public class InlineScannerRemoteExecutorTests {
   }
 
   @Test
-  public void dockerSocketIsMountedWithInvalidPath() throws Exception {
+  public void dockerSocketIsMountedWithNotLocalPath() throws Exception {
     String customVolumePath = "tcp://foo:/var/run";
 
     setupMocks();
@@ -222,6 +222,15 @@ public class InlineScannerRemoteExecutorTests {
       any(),
       any(),
       argThat(args -> args.equals(Collections.emptyList())));
+  }
+
+  @Test
+  public void dockerSocketIsMountedWithInvalidPath() {
+    String customVolumePath = tempPath + "whatever";
+
+    nodeEnvVars.override("DOCKER_HOST", customVolumePath);
+
+    assertThrows(AbortException.class, () -> scannerRemoteExecutor.call());
   }
 
 

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
@@ -159,7 +159,7 @@ public class InlineScannerRemoteExecutorTests {
   }
 
   @Test
-  public void dockerSocketIsMounted() throws Exception {
+  public void dockerSocketIsMountedWithDefaultValue() throws Exception {
     setupMocks();
 
     // When
@@ -174,6 +174,27 @@ public class InlineScannerRemoteExecutorTests {
       any(),
       argThat(args -> args.contains("/var/run/docker.sock:/var/run/docker.sock")));
   }
+
+  @Test
+  public void dockerSocketIsMountedWithCorrectPath() throws Exception {
+    String customVolumePath = "/myroot/volume";
+
+    setupMocks();
+    nodeEnvVars.override("DOCKER_HOST", customVolumePath);
+
+    // When
+    scannerRemoteExecutor.call();
+
+    // Then
+    verify(containerRunner, times(1)).createContainer(
+      eq(SCAN_IMAGE),
+      argThat(args -> args.contains("cat")),
+      any(),
+      any(),
+      any(),
+      argThat(args -> args.contains(customVolumePath + ":/var/run/docker.sock")));
+  }
+
 
   @Test
   public void logOutputIsSentToTheLogger() throws Exception {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The env variable `DOCKER_HOST` was not taken into account when mounting a volume, the volume was mounted to an hardcoded path instead. With the fix, the host path is read from the above mentioned env variable, if not set the default hardcoded value is used.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

