### PR TITLE
Add back volume mounting when docker host is a tcp-like url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>sysdig-secure</artifactId>
-  <version>2.1.16-SNAPSHOT</version>
+  <version>2.1.16</version>
   <packaging>hpi</packaging>
   <name>Sysdig Secure Container Image Scanner Plugin</name>
   <description>Integrates Jenkins with the Sysdig Secure Image Scanner to scan OCI images</description>

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/scanner/InlineScannerRemoteExecutorTests.java
@@ -222,7 +222,7 @@ public class InlineScannerRemoteExecutorTests {
       any(),
       any(),
       any(),
-      argThat(args -> args.equals(Collections.emptyList())));
+      argThat(args -> args.contains("/var/run/docker.sock:/var/run/docker.sock")));
   }
 
   @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
When solving a problem managing the `DOCKER_HOST` env variable (see https://github.com/jenkinsci/sysdig-secure-plugin/pull/55), tcp docker daemon case had been broken.
This PR puts back the mount of default daemon socket `"/var/run/docker.sock"`, so that if this file is present in the remote host, tcp usecase will be working again.
I have reproduced locally the issue with version 2.1.15 setting the docker host to a local tcp url (with a docker in docker behind that url), this change makes the plugin work.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


