### PR TITLE
New engine-scanner is now using its own subfolders to store temp files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>sysdig-secure</artifactId>
-  <version>2.2.4-BETA</version>
+  <version>2.2.4-rc</version>
   <packaging>hpi</packaging>
   <name>Sysdig Secure Container Image Scanner Plugin</name>
   <description>Integrates Jenkins with the Sysdig Secure Image Scanner to scan OCI images</description>

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineReportConverter.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineReportConverter.java
@@ -67,34 +67,37 @@ public class NewEngineReportConverter extends ReportConverter{
     JSONObject result = new JSONObject();
 
 
-
-    imageResult.getGateResult().getJSONArray("list").forEach(policy -> {
-      if (((JSONObject)policy).getInt("failuresCount")>0){
-        ((JSONObject)policy).getJSONArray("bundle").forEach(item ->{
-          if (((JSONObject) item).getInt("failuresCount") > 0) {
-            ((JSONObject)item).getJSONArray("rules").forEach(rule -> {
-              if (((JSONObject) rule).getInt("failuresCount") > 0) {
-                String ruleString = getRuleString(((JSONObject) rule).getJSONArray("predicates"));
-                ((JSONObject)rule).getJSONArray("pkgVulnFailures").forEach(failure -> {
-                  JSONArray row = new JSONArray();
-                  row.element(imageResult.getImageDigest());
-                  row.element(imageResult.getTag());
-                  row.element("trigger_id");
-                  row.element(((JSONObject) item).getString("name"));
-                  row.add(ruleString );
-                  row.add(getPkgVulnFailuresString((JSONObject)failure));
-                  row.element("STOP");
-                  row.element(false);
-                  row.element("");
-                  row.element(((JSONObject) policy).getString("name"));
-                  rows.element(row);
-                });
-              }
-            });
-          }
-        });
-      }
-    });
+    if(imageResult.getGateResult()!=null && imageResult.getGateResult().optJSONArray("list")!=null){
+      imageResult.getGateResult().getJSONArray("list").forEach(policy -> {
+        if (((JSONObject)policy).getInt("failuresCount")>0){
+          ((JSONObject)policy).getJSONArray("bundle").forEach(item ->{
+            if (((JSONObject) item).getInt("failuresCount") > 0) {
+              ((JSONObject)item).getJSONArray("rules").forEach(rule -> {
+                if (((JSONObject) rule).getInt("failuresCount") > 0) {
+                  if (((JSONObject) rule).has("pkgVulnFailures")) {
+                    String ruleString = getRuleString(((JSONObject) rule).getJSONArray("predicates"));
+                    ((JSONObject) rule).getJSONArray("pkgVulnFailures").forEach(failure -> {
+                      JSONArray row = new JSONArray();
+                      row.element(imageResult.getImageDigest());
+                      row.element(imageResult.getTag());
+                      row.element("trigger_id");
+                      row.element(((JSONObject) item).getString("name"));
+                      row.add(ruleString);
+                      row.add(getPkgVulnFailuresString((JSONObject) failure));
+                      row.element("STOP");
+                      row.element(false);
+                      row.element("");
+                      row.element(((JSONObject) policy).getString("name"));
+                      rows.element(row);
+                    });
+                  }
+                }
+              });
+            }
+          });
+        }
+      });
+    }
 
     result.put("header",headers);
     String finalAction = imageResult.getEvalStatus().equalsIgnoreCase("failed") ? "STOP" : "GO";

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
@@ -20,24 +20,94 @@ import com.sysdig.jenkins.plugins.sysdig.NewEngineBuildConfig;
 import com.sysdig.jenkins.plugins.sysdig.log.SysdigLogger;
 import hudson.AbortException;
 import hudson.EnvVars;
+import hudson.FilePath;
 import hudson.remoting.Callable;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.Tailer;
+import org.apache.commons.io.input.TailerListenerAdapter;
 import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.*;
-import java.net.*;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 
 public class NewEngineRemoteExecutor implements Callable<String, Exception>, Serializable {
 
-  //TODO: ...
+  private static final String FIXED_SCANNED_VERSION = "1.2.5";
+
+  public static class LogsFileToLoggerForwarder extends TailerListenerAdapter {
+
+    private final SysdigLogger logger;
+
+    public LogsFileToLoggerForwarder(final SysdigLogger forwardTo){
+      this.logger = forwardTo;
+    }
+
+    public void handle(String line) {
+      this.logger.logInfo(line);
+    }
+  }
+
+  private static class ScannerPaths {
+    private static final String SCANNER_EXEC_FOLDER_BASE_PATH_PATTERN = "sysdig-secure-scan-%d";
+    private final Path baseFolder;
+    private final Path binFolder;
+    private final Path databaseFolder;
+    private final Path cacheFolder;
+    private final Path tmpFolder;
+
+    public ScannerPaths(final FilePath basePath) {
+      this.baseFolder = Paths.get(basePath.getRemote(), String.format(SCANNER_EXEC_FOLDER_BASE_PATH_PATTERN, System.currentTimeMillis()));
+      this.binFolder = Paths.get(this.baseFolder.toString(), "bin");
+      this.databaseFolder = Paths.get(this.baseFolder.toString(), "db");
+      this.cacheFolder = Paths.get(this.baseFolder.toString(), "cache");
+      this.tmpFolder = Paths.get(this.baseFolder.toString(), "tmp");
+    }
+
+    public Path getBaseFolder() {
+      return this.baseFolder;
+    }
+
+    public Path getBinFolder() {
+      return this.binFolder;
+    }
+
+    public Path getDatabaseFolder() {
+      return this.databaseFolder;
+    }
+
+    public Path getCacheFolder() {
+      return this.cacheFolder;
+    }
+
+    public Path getTmpFolder() {
+      return this.tmpFolder;
+    }
+
+    public void create() throws Exception {
+      Files.createDirectories(this.baseFolder);
+      Files.createDirectory(this.binFolder);
+      Files.createDirectory(this.databaseFolder);
+      Files.createDirectory(this.cacheFolder);
+      Files.createDirectory(this.tmpFolder);
+    }
+
+    public void purge() throws IOException {
+      FileUtils.deleteDirectory(this.baseFolder.toFile());
+    }
+  }
+
+  private final ScannerPaths scannerPaths;
   private final String imageName;
   private final String dockerFile;
   private final NewEngineBuildConfig config;
@@ -45,29 +115,28 @@ public class NewEngineRemoteExecutor implements Callable<String, Exception>, Ser
   private final EnvVars envVars;
   private final String[] noProxy;
 
-  public NewEngineRemoteExecutor(String imageName, String dockerFile, NewEngineBuildConfig config, SysdigLogger logger, EnvVars envVars) {
+  public NewEngineRemoteExecutor(FilePath workspace, String imageName, String dockerFile, NewEngineBuildConfig config, SysdigLogger logger, EnvVars envVars) {
     this.imageName = imageName;
     this.dockerFile = dockerFile;
     this.config = config;
     this.logger = logger;
     this.envVars = envVars;
-
+    this.scannerPaths = new ScannerPaths(workspace);
 
     if (envVars.containsKey("no_proxy") || envVars.containsKey("NO_PROXY")) {
-      String noProxy= envVars.getOrDefault("no_proxy",envVars.get("NO_PROXY"));
+      String noProxy = envVars.getOrDefault("no_proxy", envVars.get("NO_PROXY"));
       this.noProxy = noProxy.split(",");
     } else {
       this.noProxy = new String[0];
     }
-
   }
 
   @Override
-  public void checkRoles(RoleChecker checker) throws SecurityException { }
+  public void checkRoles(RoleChecker checker) throws SecurityException {
+  }
+
   @Override
-
-  public String call() throws InterruptedException, AbortException {
-
+  public String call() throws AbortException {
     if (!Strings.isNullOrEmpty(dockerFile)) {
       File f = new File(dockerFile);
       if (!f.exists()) {
@@ -75,165 +144,52 @@ public class NewEngineRemoteExecutor implements Callable<String, Exception>, Ser
       }
     }
 
-    //Download
-    File tmpBinary;
-
-    if (!config.getScannerBinaryPath().isEmpty()) {
-      tmpBinary = new File(config.getScannerBinaryPath());
-      logger.logInfo("Inlinescan binary globally defined to* " + tmpBinary.getPath());
-    }else {
-      try {
-        String latestVersion = getInlineScanLatestVersion();
-        logger.logInfo("Downloading inlinescan v" + latestVersion);
-        tmpBinary = downloadInlineScan(latestVersion);
-        logger.logInfo("Inlinescan binary downloaded to " + tmpBinary.getPath());
-        Files.setPosixFilePermissions(tmpBinary.toPath(), EnumSet.of(PosixFilePermission.OWNER_EXECUTE));
-      } catch (IOException e) {
-        throw new AbortException("Error downloading inlinescan binary: " + e);
-      }
-    }
-    //Prepare args and execute
     try {
-      File scanLog = File.createTempFile("inlinescan", ".log");
-      File scanResult = File.createTempFile("inlinescan", ".json");
-      List<String> command = new ArrayList<>();
-      command.add(tmpBinary.getPath());
-      command.add("--apiurl");
-      command.add(config.getEngineurl());
-      command.add("--logfile");
-      command.add(scanLog.getAbsolutePath());
-      command.add("--output-json");
-      command.add(scanResult.getAbsolutePath());
-
-      for (String extraParam : config.getInlineScanExtraParams().split(" ")) {
-        if (!Strings.isNullOrEmpty(extraParam)) {
-          command.add(extraParam);
-        }
-      }
-
-      for (String policyId : config.getPoliciesToApply().split(" ")) {
-        if (!Strings.isNullOrEmpty(policyId)) {
-          command.add("--policy");
-          command.add(policyId);
-        }
-      }
-
-      if (!config.getEngineverify()) {
-        command.add("--skiptlsverify");
-      }
-
-      if (config.getDebug()) {
-        command.add("--loglevel=debug");
-      }
-
-      command.add(this.imageName);
-
-      List<String> env = new ArrayList<>();
-      env.add("SECURE_API_TOKEN=" + config.getSysdigToken());
-      for (Map.Entry<String, String> entry : envVars.entrySet()) {
-        env.add(entry.getKey() + "=" + entry.getValue());
-      }
-
-      logger.logInfo("Executing: " + String.join(" ", command));
-      Process p = Runtime.getRuntime().exec(command.toArray(new String[0]), env.toArray(new String[0]));
-
-      //     String stderr = IOUtils.toString(p.getErrorStream(), Charset.defaultCharset());
-     // String stdout = IOUtils.toString(p.getInputStream(), Charset.defaultCharset());
-
-
-      class PrimeThread extends Thread {
-        Process p;
-        SysdigLogger logger;
-        BufferedReader or=null;
-        String output = "";
-        PrimeThread(Process p, SysdigLogger logger) {
-          this.p = p;
-          this.logger=logger;
-        }
-
-        public void run() {
-          try {
-            SequenceInputStream message = new SequenceInputStream(p.getInputStream(),p.getErrorStream());
-
-            or = new BufferedReader(new InputStreamReader(message,Charset.defaultCharset()));
-
-            while ((output = or.readLine()) != null) {
-             logger.logInfo(output);
-            }
-          }
-          catch (IOException ioe) {
-           logger.logError("Exception while reading input " + ioe);
-          }
-          finally {
-            // close the streams using close method
-            try {
-              if (or != null) {
-                or.close();
-              }
-            }
-            catch (IOException ioe) {
-              logger.logError("Error while closing stream: " + ioe);
-            }
-          }
-        }
-      }
-
-      PrimeThread thread = new PrimeThread(p,logger);
-      thread.start();
-
-
-      int retCode = p.waitFor();
-          thread.join();
-
-      logger.logInfo("Inlinescan exit code: " + retCode);
-
-     // logger.logInfo("Inline scan output:\n" + stdout);
-     // String stderr = IOUtils.toString(p.getErrorStream(), Charset.defaultCharset());
-     // logger.logInfo("Inline scan error:\n" + stderr);
-
-      logger.logDebug("Inline scan logs:\n" + new String(Files.readAllBytes(Paths.get(scanLog.getAbsolutePath())), Charset.defaultCharset()));
-
-      //TODO: For exit code 2 (wrong params), just show the output (should not happen, but just in case)
-      String jsonOutput = new String(Files.readAllBytes(Paths.get(scanResult.getAbsolutePath())), Charset.defaultCharset());
-      logger.logDebug("Inline scan JSON output:\n" + jsonOutput);
-
-      if ( retCode == 2 ) {
-        jsonOutput = "{error:\"Wrong parameters in call to inline scanner\"}";
-      } else if ( retCode == 3 ) {
-        jsonOutput = "{error:\"Unexpected error when executing scan\"}";
-      }else if ( retCode != 0 && retCode != 1 ) {
-        throw new Exception("Cannot manage return code");
-      }
-
-      return jsonOutput;
-
-    } catch (Exception e) {
-      throw new AbortException("Error executing inlinescan binary: " + e);
+      // Create all the necessary folders to store execution temp files and such
+      createExecutionWorkspace();
+      // Retrieve the scanner bin file
+      final File scannerBinaryFile = retrieveScannerBinFile();
+      // Execute the scanner bin file and retrieves its json output
+      return executeScan(scannerBinaryFile);
+    } finally {
+      purgeExecutionWorkspace();
     }
-
   }
 
-  private File downloadInlineScan(String latestVersion) throws IOException {
-    File tmpBinary = File.createTempFile("inlinescan", "-" + latestVersion + ".bin");
+  private File downloadInlineScan(String latestVersion) throws IOException, UnsupportedOperationException, InterruptedException {
+    final File scannerBinFile = Files.createFile(Paths.get(this.scannerPaths.getBinFolder().toString(), String.format("inlinescan-%s.bin", latestVersion))).toFile();
     logger.logInfo(System.getProperty("os.name"));
 
-    String os = System.getProperty("os.name").toLowerCase().startsWith("mac") ? "darwin":"linux";
-    URL url = new URL("https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/" + latestVersion + "/"+os+"/amd64/sysdig-cli-scanner");
+    String os = System.getProperty("os.name").toLowerCase().startsWith("mac") ? "darwin" : "linux";
+    URL url = new URL("https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/" + latestVersion + "/" + os + "/amd64/sysdig-cli-scanner");
     Proxy proxy = getHttpProxy();
-    Boolean proxyException = Arrays.asList(noProxy).contains("sysdig.com") || Arrays.asList(noProxy).contains("download.sysdig.com");
-    if (proxy != Proxy.NO_PROXY && proxy.type() != Proxy.Type.DIRECT && !proxyException) {
-      FileUtils.copyInputStreamToFile(url.openConnection(proxy).getInputStream(),tmpBinary);
-    } else {
-      FileUtils.copyURLToFile(url, tmpBinary);
-    }
+    boolean proxyException = Arrays.asList(noProxy).contains("sysdig.com") || Arrays.asList(noProxy).contains("download.sysdig.com");
+    int downloadRetriesLeft = 5;
+    while (true) {
+      try {
+        if (proxy != Proxy.NO_PROXY && proxy.type() != Proxy.Type.DIRECT && !proxyException) {
+          FileUtils.copyInputStreamToFile(url.openConnection(proxy).getInputStream(), scannerBinFile);
+        } else {
+          FileUtils.copyURLToFile(url, scannerBinFile);
+        }
 
-    return tmpBinary;
+        Files.setPosixFilePermissions(scannerBinFile.toPath(), EnumSet.of(PosixFilePermission.OWNER_EXECUTE));
+        return scannerBinFile;
+      } catch (Exception e) {
+        downloadRetriesLeft--;
+        if (downloadRetriesLeft > 0) {
+          TimeUnit.SECONDS.sleep(2L);
+        } else {
+          throw e;
+        }
+      }
+    }
   }
 
   private String getInlineScanLatestVersion() throws IOException {
     URL url = new URL("https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt");
     Proxy proxy = getHttpProxy();
-    Boolean proxyException = Arrays.asList(noProxy).contains("sysdig.com") || Arrays.asList(noProxy).contains("download.sysdig.com");
+    boolean proxyException = Arrays.asList(noProxy).contains("sysdig.com") || Arrays.asList(noProxy).contains("download.sysdig.com");
     if (proxy != Proxy.NO_PROXY && proxy.type() != Proxy.Type.DIRECT && !proxyException) {
       try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openConnection(proxy).getInputStream(), StandardCharsets.UTF_8))) {
         return reader.readLine();
@@ -245,27 +201,29 @@ public class NewEngineRemoteExecutor implements Callable<String, Exception>, Ser
     }
   }
 
+  private String getInlineScanPinnedVersion() {
+    return FIXED_SCANNED_VERSION;
+  }
+
   private Proxy getHttpProxy() throws IOException {
     Proxy proxy;
-    String address="";
-    Integer port;
+    String address = "";
+    int port;
     URL proxyURL;
 
-
-
     if (envVars.containsKey("https_proxy") || envVars.containsKey("HTTPS_PROXY")) {
-      address = envVars.getOrDefault("https_proxy",envVars.get("HTTPS_PROXY"));
+      address = envVars.getOrDefault("https_proxy", envVars.get("HTTPS_PROXY"));
     } else if (envVars.containsKey("http_proxy") || envVars.containsKey("HTTP_PROXY")) {
-      address = envVars.getOrDefault("https_proxy",envVars.get("HTTPS_PROXY"));
+      address = envVars.getOrDefault("https_proxy", envVars.get("HTTPS_PROXY"));
     }
 
     if (!address.isEmpty()) {
-      if (!address.startsWith("http://") && !address.startsWith("https://")){
+      if (!address.startsWith("http://") && !address.startsWith("https://")) {
         address = "http://" + address;
       }
       proxyURL = new URL(address);
-      port = proxyURL.getPort()!=-1 ? proxyURL.getPort() : 80;
-      proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyURL.getHost(),port));
+      port = proxyURL.getPort() != -1 ? proxyURL.getPort() : 80;
+      proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyURL.getHost(), port));
     } else {
       proxy = Proxy.NO_PROXY;
     }
@@ -273,5 +231,107 @@ public class NewEngineRemoteExecutor implements Callable<String, Exception>, Ser
     return proxy;
   }
 
+  private void createExecutionWorkspace() throws AbortException {
+    try {
+      this.scannerPaths.create();
+    } catch (Exception e) {
+      logger.logError("Unable to create scanner execution workspace", e);
+      throw new AbortException("Unable to create scanner execution workspace");
+    }
+  }
+
+  private void purgeExecutionWorkspace() {
+    try {
+      this.scannerPaths.purge();
+    } catch (IOException e) {
+      logger.logError("Unable to delete scanner execution workspace", e);
+    }
+  }
+
+  private File retrieveScannerBinFile() throws AbortException {
+    File scannerBinaryPath;
+
+    if (!config.getScannerBinaryPath().isEmpty()) {
+      scannerBinaryPath = new File(config.getScannerBinaryPath());
+      logger.logInfo("Inlinescan binary globally defined to* " + scannerBinaryPath.getPath());
+    } else {
+      try {
+        String latestVersion = getInlineScanPinnedVersion();
+        logger.logInfo("Downloading inlinescan v" + latestVersion);
+        scannerBinaryPath = downloadInlineScan(latestVersion);
+        logger.logInfo("Inlinescan binary downloaded to " + scannerBinaryPath.getPath());
+      } catch (IOException | InterruptedException e) {
+        throw new AbortException("Error downloading inlinescan binary: " + e);
+      }
+    }
+    return scannerBinaryPath;
+  }
+
+  private String executeScan(final File scannerBinFile) throws AbortException {
+    try {
+      final File scannerJsonOutputFile = Files.createFile(Paths.get(this.scannerPaths.getBaseFolder().toString(), "inlinescan.json")).toFile();
+      final File scannerExecLogsFile = Files.createFile(Paths.get(this.scannerPaths.getBaseFolder().toString(), "inlinescan-logs.log")).toFile();
+      final Tailer logsFileTailer = Tailer.create(scannerExecLogsFile, new LogsFileToLoggerForwarder(this.logger), 500L);
+
+      List<String> command = new ArrayList<>();
+      command.add(scannerBinFile.getPath());
+      command.add(String.format("--apiurl=%s", this.config.getEngineurl()));
+      command.add(String.format("--dbpath=%s", this.scannerPaths.getDatabaseFolder()));
+      command.add(String.format("--cachepath=%s", this.scannerPaths.getCacheFolder()));
+//      command.add(String.format("--logfile=%s", scannerExecLogsFile.getAbsolutePath()));
+      command.add(String.format("--output-json=%s", scannerJsonOutputFile.getAbsolutePath()));
+      command.add("--console-log");
+
+      if (this.config.getDebug()) {
+        command.add("--loglevel=debug");
+      }
+      if (!this.config.getEngineverify()) {
+        command.add("--skiptlsverify");
+      }
+
+      for (String extraParam : this.config.getInlineScanExtraParams().split(" ")) {
+        if (!Strings.isNullOrEmpty(extraParam)) {
+          command.add(extraParam);
+        }
+      }
+      for (String policyId : this.config.getPoliciesToApply().split(" ")) {
+        if (!Strings.isNullOrEmpty(policyId)) {
+          command.add(String.format("--policy=%s", policyId));
+        }
+      }
+
+      command.add(this.imageName);
+
+      final ProcessBuilder processBuilder = new ProcessBuilder().command(command).redirectOutput(scannerExecLogsFile).redirectError(scannerExecLogsFile);
+      final Map<String, String> processEnv = processBuilder.environment();
+      processEnv.putAll(this.envVars);
+      processEnv.put("TMPDIR", this.scannerPaths.getTmpFolder().toString());
+      processEnv.put("SECURE_API_TOKEN", this.config.getSysdigToken());
+
+      logger.logInfo("Executing: " + String.join(" ", command));
+      final Process scannerProcess = processBuilder.start();
+
+      logger.logInfo("Waiting for scanner execution to be completed...");
+      int scannerExitCode = scannerProcess.waitFor();
+      logsFileTailer.stop();
+      logger.logInfo(String.format("Scanner exit code: %d", scannerExitCode));
+
+      //TODO: For exit code 2 (wrong params), just show the output (should not happen, but just in case)
+      String jsonOutput = new String(Files.readAllBytes(Paths.get(scannerJsonOutputFile.getAbsolutePath())), Charset.defaultCharset());
+      logger.logDebug("Inline scan JSON output:\n" + jsonOutput);
+
+      if (scannerExitCode == 2) {
+        jsonOutput = "{error:\"Wrong parameters in call to inline scanner\"}";
+      } else if (scannerExitCode == 3) {
+        jsonOutput = "{error:\"Unexpected error when executing scan\"}";
+      } else if (scannerExitCode != 0 && scannerExitCode != 1) {
+        throw new Exception("Cannot manage return code");
+      }
+
+      return jsonOutput;
+    } catch (Exception e) {
+      throw new AbortException("Error executing inlinescan binary: " + e);
+    }
+  }
 
 }


### PR DESCRIPTION
New scanner engine binary and all files related to its execution are now stored inside its own folder in the Jenkins workspace.
All subfolders are created under a parent folder (`sysdig-secure-scan-CURRENT_TIMESTAMP`) as soon as the `NewEngineRemoteExecutor` starts its execution and completely purged as soon as it ends.

In addition:
1) the `--console-log` is now provided instead of `--logfile` param so that we have all the logs at console level
2) a retry (set to 5) is performed when trying to download the scanner binary file

DO NOT MERGE BECAUSE A CUSTOM HPI IS GOING TO BE BUILT FROM HERE AND CHANGES ARE GOING TO BE CHERRY-PICKED ON TOP OF THE `new-engine` BRANCH