### PR TITLE
feature: Updates cli-scanner to version 1.3.1 + update a few dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,13 @@
   </pluginRepositories>
 
   <dependencies>
+    <!-->This dependency could be updated to the latest version (before the incremental process): 2.6.2
+    In order to do so, 'structs' dependency needs to be updated as well to at least 1.23, which requires
+    Jenkins to be at least at version 2.222<!-->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.18</version>
+      <version>2.3.11</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -70,47 +73,32 @@
     <dependency>
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java</artifactId>
-      <version>3.2.13</version>
+      <version>3.2.14</version>
     </dependency>
     <dependency>
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java-transport-httpclient5</artifactId>
-      <version>3.2.13</version>
+      <version>3.2.14</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
+      <version>1.7.36</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.30</version>
+      <version>1.7.36</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
-      <version>2.6.0</version>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
       <version>2.10.3</version>
-    </dependency>
-    <dependency> <!-- required by docker-java -->
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>19.0</version>
-    </dependency>
-    <dependency> <!-- required by docker-java-core -->
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
-    </dependency>
-    <dependency> <!-- required by docker-java-transport-httpclient5 -->
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.13</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -120,7 +108,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.19</version>
+      <version>2.20</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -161,7 +149,8 @@
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-definition</artifactId>
-      <version>1.2</version>
+      <version>1.2.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
@@ -172,7 +161,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -182,7 +171,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>structs</artifactId>
-        <version>1.17</version>
+        <version>1.21</version> <!-->This is the most-updated version supporting Jenkins 1.150.1<!-->
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -195,16 +184,6 @@
         <artifactId>scm-api</artifactId>
         <version>2.2.6</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.12.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>2.10.3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>3.57</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <artifactId>sysdig-secure</artifactId>
@@ -59,7 +60,7 @@
   <dependencies>
     <!-->This dependency could be updated to the latest version (before the incremental process): 2.6.2
     In order to do so, 'structs' dependency needs to be updated as well to at least 1.23, which requires
-    Jenkins to be at least at version 2.222<!-->
+    Jenkins to be at least at version 2.222<-->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
@@ -101,14 +102,16 @@
       <version>2.10.3</version>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
       <version>2.20</version>
+    </dependency>
+
+    <!--TEST Dependencies-->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -171,8 +174,10 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>structs</artifactId>
-        <version>1.21</version> <!-->This is the most-updated version supporting Jenkins 1.150.1<!-->
+        <version>1.21</version> <!-->This is the most-updated version supporting Jenkins 1.150.1<-->
       </dependency>
+
+      <!--TEST Dependencies-->
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>script-security</artifactId>
@@ -190,7 +195,6 @@
 
   <build>
     <plugins>
-
       <!-- download external resources like jQuery, jQuery UI, datatable etc. via webjars -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 public class NewEngineRemoteExecutor implements Callable<String, Exception>, Serializable {
 
-  private static final String FIXED_SCANNED_VERSION = "1.2.5";
+  private static final String FIXED_SCANNED_VERSION = "1.3.1";
 
   public static class LogsFileToLoggerForwarder extends TailerListenerAdapter {
 


### PR DESCRIPTION
- Updates the `sysdig-cli-scanner` to version `1.3.1` in order to support the new Sysdig **Risks-Acceptance** feature
- Bump version of a few dependencies to latest available for our currently supported minimum Jenkins version (2.150)