### PR TITLE
bugfix: Evaluation gate status is now PASS when scan-result is 'accepted'

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/ReportConverter.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/ReportConverter.java
@@ -15,6 +15,10 @@ import java.util.HashMap;
 import java.util.List;
 
 public class ReportConverter {
+  private static final String LEGACY_PASSED_STATUS = "pass";
+  private static final String PASSED_STATUS = "passed";
+  private static final String ACCEPTED_STATUS = "accepted";
+
   protected final SysdigLogger logger;
 
   public ReportConverter(SysdigLogger logger) {
@@ -29,7 +33,7 @@ public class ReportConverter {
 
       logger.logDebug(String.format("Get policy evaluation status for image '%s': %s", result.getTag(), evalStatus));
 
-      if (!"pass".equals(evalStatus) && !"passed".equals(evalStatus)) {
+      if (!evalStatus.equalsIgnoreCase(LEGACY_PASSED_STATUS) && !evalStatus.equalsIgnoreCase(PASSED_STATUS) && !evalStatus.equalsIgnoreCase(ACCEPTED_STATUS)) {
         finalAction = Util.GATE_ACTION.FAIL;
       }
     }

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/ReportConverterTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/ReportConverterTests.java
@@ -42,7 +42,9 @@ public class ReportConverterTests {
     // Given
     List<ImageScanningResult> results = new ArrayList<>();
     results.add(new ImageScanningResult("foo-tag1", "foo-digest1", "pass", new JSONObject(), new JSONObject(), new JSONArray()));
-    results.add(new ImageScanningResult("foo-tag2", "foo-digest2", "pass", new JSONObject(), new JSONObject(), new JSONArray()));
+    results.add(new ImageScanningResult("foo-tag2", "foo-digest2", "passed", new JSONObject(), new JSONObject(), new JSONArray()));
+    results.add(new ImageScanningResult("foo-tag3", "foo-digest2", "accepted", new JSONObject(), new JSONObject(), new JSONArray()));
+    results.add(new ImageScanningResult("foo-tag4", "foo-digest2", "ACCEPTED", new JSONObject(), new JSONObject(), new JSONArray()));
 
     // Then
     assertEquals(Util.GATE_ACTION.PASS, converter.getFinalAction(results));
@@ -54,6 +56,7 @@ public class ReportConverterTests {
     List<ImageScanningResult> results = new ArrayList<>();
     results.add(new ImageScanningResult("foo-tag1", "foo-digest1", "pass", new JSONObject(), new JSONObject(), new JSONArray()));
     results.add(new ImageScanningResult("foo-tag2", "foo-digest2", "fail", new JSONObject(), new JSONObject(), new JSONArray()));
+    results.add(new ImageScanningResult("foo-tag3", "foo-digest2", "accepted", new JSONObject(), new JSONObject(), new JSONArray()));
 
     // Then
     assertEquals(Util.GATE_ACTION.FAIL, converter.getFinalAction(results));


### PR DESCRIPTION
As per title: the evaluation gate status was failing because it was not taking into consideration the newly added status (**accepted)** from the internal _scanner_