### PR TITLE
bugfix: 'noPolicy' is now accepted as valid result in order for the policy gate to be PASS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,8 @@
           <compilerArgs>
             <arg>-Xlint:all</arg>
           </compilerArgs>
+          <source>9</source>
+          <target>9</target>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -300,8 +300,6 @@
           <compilerArgs>
             <arg>-Xlint:all</arg>
           </compilerArgs>
-          <source>9</source>
-          <target>9</target>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/ReportConverter.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/ReportConverter.java
@@ -18,6 +18,7 @@ public class ReportConverter {
   private static final String LEGACY_PASSED_STATUS = "pass";
   private static final String PASSED_STATUS = "passed";
   private static final String ACCEPTED_STATUS = "accepted";
+  private static final String NO_POLICY_STATUS = "noPolicy";
 
   protected final SysdigLogger logger;
 
@@ -33,7 +34,7 @@ public class ReportConverter {
 
       logger.logDebug(String.format("Get policy evaluation status for image '%s': %s", result.getTag(), evalStatus));
 
-      if (!evalStatus.equalsIgnoreCase(LEGACY_PASSED_STATUS) && !evalStatus.equalsIgnoreCase(PASSED_STATUS) && !evalStatus.equalsIgnoreCase(ACCEPTED_STATUS)) {
+      if (!evalStatus.equalsIgnoreCase(LEGACY_PASSED_STATUS) && !evalStatus.equalsIgnoreCase(PASSED_STATUS) && !evalStatus.equalsIgnoreCase(ACCEPTED_STATUS) && !evalStatus.equalsIgnoreCase(NO_POLICY_STATUS)) {
         finalAction = Util.GATE_ACTION.FAIL;
       }
     }

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/ReportConverterTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/ReportConverterTests.java
@@ -45,6 +45,7 @@ public class ReportConverterTests {
     results.add(new ImageScanningResult("foo-tag2", "foo-digest2", "passed", new JSONObject(), new JSONObject(), new JSONArray()));
     results.add(new ImageScanningResult("foo-tag3", "foo-digest2", "accepted", new JSONObject(), new JSONObject(), new JSONArray()));
     results.add(new ImageScanningResult("foo-tag4", "foo-digest2", "ACCEPTED", new JSONObject(), new JSONObject(), new JSONArray()));
+    results.add(new ImageScanningResult("foo-tag5", "foo-digest2", "noPolicy", new JSONObject(), new JSONObject(), new JSONArray()));
 
     // Then
     assertEquals(Util.GATE_ACTION.PASS, converter.getFinalAction(results));
@@ -57,6 +58,8 @@ public class ReportConverterTests {
     results.add(new ImageScanningResult("foo-tag1", "foo-digest1", "pass", new JSONObject(), new JSONObject(), new JSONArray()));
     results.add(new ImageScanningResult("foo-tag2", "foo-digest2", "fail", new JSONObject(), new JSONObject(), new JSONArray()));
     results.add(new ImageScanningResult("foo-tag3", "foo-digest2", "accepted", new JSONObject(), new JSONObject(), new JSONArray()));
+    results.add(new ImageScanningResult("foo-tag5", "foo-digest2", "noPolicy", new JSONObject(), new JSONObject(), new JSONArray()));
+
 
     // Then
     assertEquals(Util.GATE_ACTION.FAIL, converter.getFinalAction(results));


### PR DESCRIPTION
`noPolicy` status from the embedded scanner is now accepted as **PASS** on the policy gate