### PR TITLE
Add ability to specify sysdig secure cli version to use for scanning

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/BuildConfig.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/BuildConfig.java
@@ -43,6 +43,8 @@ public class BuildConfig implements Serializable {
   private final String sysdigToken;
   private final boolean forceScan;
   private final String inlineScanImage;
+  private final String cliVersionToApply;
+  private final String customCliVersion;
 
   public BuildConfig(SysdigBuilder.DescriptorImpl globalConfig, SysdigScanStep scanStep, String sysdigToken) {
     imageListName = scanStep.getName();
@@ -56,6 +58,9 @@ public class BuildConfig implements Serializable {
       engineurl = globalConfig.getEngineurl();
       engineverify = globalConfig.getEngineverify();
     }
+
+    cliVersionToApply = globalConfig.getCliVersionToApply();
+    customCliVersion = globalConfig.getCustomCliVersion();
 
     if (!Strings.isNullOrEmpty(scanStep.getRunAsUser())) {
       runAsUser = scanStep.getRunAsUser();
@@ -98,6 +103,14 @@ public class BuildConfig implements Serializable {
 
   public boolean getDebug() {
     return debug;
+  }
+
+  public String getCliVersionToApply() {
+    return cliVersionToApply;
+  }
+
+  public String getCustomCliVersion() {
+    return customCliVersion;
   }
 
   public String getEngineurl() {
@@ -148,6 +161,8 @@ public class BuildConfig implements Serializable {
     }
 
     logger.logInfo(String.format("debug: %s", this.getDebug()));
+    logger.logInfo(String.format("cliVersionToApply: %s", this.getCliVersionToApply()));
+    logger.logInfo(String.format("customCliVersion: %s", this.getCustomCliVersion()));
     logger.logInfo(String.format("inlineScanning: %s", this.getInlineScanning()));
     logger.logInfo(String.format("engineurl: %s", this.getEngineurl()));
     logger.logInfo(String.format("engineverify: %s", this.getEngineverify()));

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuildConfig.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuildConfig.java
@@ -35,6 +35,7 @@ public class NewEngineBuildConfig implements Serializable {
   private final String sysdigToken;
   private final String policiesToApply;
   private final String scannerBinaryPath;
+  private final String cliVersionToApply;
 
   public NewEngineBuildConfig(SysdigBuilder.DescriptorImpl globalConfig, NewEngineScanStep scanStep, String sysdigToken) {
     imageName = scanStep.getImageName();
@@ -58,6 +59,7 @@ public class NewEngineBuildConfig implements Serializable {
     this.sysdigToken = sysdigToken;
 
     this.policiesToApply = scanStep.getPoliciesToApply();
+    this.cliVersionToApply = scanStep.getCliVersionToApply();
 
     if (!Strings.isNullOrEmpty(scanStep.getScannerBinaryPath())) {
       this.scannerBinaryPath = scanStep.getScannerBinaryPath();
@@ -103,6 +105,10 @@ public class NewEngineBuildConfig implements Serializable {
     return policiesToApply;
   }
 
+  public String getCliVersionToApply() {
+    return cliVersionToApply;
+  }
+
   public String getScannerBinaryPath() {
     return scannerBinaryPath;
   }
@@ -128,6 +134,7 @@ public class NewEngineBuildConfig implements Serializable {
     logger.logInfo(String.format("EngineURL: %s", this.getEngineurl()));
     logger.logInfo(String.format("EngineVerify: %s", this.getEngineverify()));
     logger.logInfo(String.format("Policies: %s", this.getPoliciesToApply()));
+    logger.logInfo(String.format("CliVersion: %s", this.getCliVersionToApply()));
     logger.logInfo(String.format("InlineScanExtraParams: %s", this.getInlineScanExtraParams()));
     logger.logInfo(String.format("BailOnFail: %s", this.getBailOnFail()));
     logger.logInfo(String.format("BailOnPluginFail: %s", this.getBailOnPluginFail()));

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuildConfig.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuildConfig.java
@@ -60,8 +60,6 @@ public class NewEngineBuildConfig implements Serializable {
     this.sysdigToken = sysdigToken;
 
     this.policiesToApply = scanStep.getPoliciesToApply();
-    // this.cliVersionToApply = globalConfig.getCliVersionToApply();
-    // this.customCliVersion = globalConfig.getCustomCliVersion();
 
     if (!Strings.isNullOrEmpty(scanStep.getCliVersionToApply())) {
       this.cliVersionToApply = scanStep.getCliVersionToApply();

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuildConfig.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuildConfig.java
@@ -36,6 +36,7 @@ public class NewEngineBuildConfig implements Serializable {
   private final String policiesToApply;
   private final String scannerBinaryPath;
   private final String cliVersionToApply;
+  private final String customCliVersion;
 
   public NewEngineBuildConfig(SysdigBuilder.DescriptorImpl globalConfig, NewEngineScanStep scanStep, String sysdigToken) {
     imageName = scanStep.getImageName();
@@ -59,7 +60,8 @@ public class NewEngineBuildConfig implements Serializable {
     this.sysdigToken = sysdigToken;
 
     this.policiesToApply = scanStep.getPoliciesToApply();
-    this.cliVersionToApply = scanStep.getCliVersionToApply();
+    this.cliVersionToApply = globalConfig.getCliVersionToApply();
+    this.customCliVersion = globalConfig.getCustomCliVersion();
 
     if (!Strings.isNullOrEmpty(scanStep.getScannerBinaryPath())) {
       this.scannerBinaryPath = scanStep.getScannerBinaryPath();
@@ -109,6 +111,10 @@ public class NewEngineBuildConfig implements Serializable {
     return cliVersionToApply;
   }
 
+  public String getCustomCliVersion() {
+    return customCliVersion;
+  }
+
   public String getScannerBinaryPath() {
     return scannerBinaryPath;
   }
@@ -135,6 +141,7 @@ public class NewEngineBuildConfig implements Serializable {
     logger.logInfo(String.format("EngineVerify: %s", this.getEngineverify()));
     logger.logInfo(String.format("Policies: %s", this.getPoliciesToApply()));
     logger.logInfo(String.format("CliVersion: %s", this.getCliVersionToApply()));
+    logger.logInfo(String.format("CustomCliVersion: %s", this.getCustomCliVersion()));
     logger.logInfo(String.format("InlineScanExtraParams: %s", this.getInlineScanExtraParams()));
     logger.logInfo(String.format("BailOnFail: %s", this.getBailOnFail()));
     logger.logInfo(String.format("BailOnPluginFail: %s", this.getBailOnPluginFail()));

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuildConfig.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuildConfig.java
@@ -61,13 +61,15 @@ public class NewEngineBuildConfig implements Serializable {
 
     this.policiesToApply = scanStep.getPoliciesToApply();
 
-    if (!Strings.isNullOrEmpty(scanStep.getCliVersionToApply())) {
+    if (!Strings.isNullOrEmpty(scanStep.getCliVersionToApply()) 
+        && !scanStep.getCliVersionToApply().equals("global_default")) {
       this.cliVersionToApply = scanStep.getCliVersionToApply();
     } else {
       this.cliVersionToApply = globalConfig.getCliVersionToApply();
     }
 
-    if (!Strings.isNullOrEmpty(scanStep.getCustomCliVersion())) {
+    if (!Strings.isNullOrEmpty(scanStep.getCustomCliVersion()) 
+        && !scanStep.getCliVersionToApply().equals("global_default")) {
       this.customCliVersion = scanStep.getCustomCliVersion();
     } else {
       this.customCliVersion = globalConfig.getCustomCliVersion();

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuildConfig.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuildConfig.java
@@ -60,8 +60,20 @@ public class NewEngineBuildConfig implements Serializable {
     this.sysdigToken = sysdigToken;
 
     this.policiesToApply = scanStep.getPoliciesToApply();
-    this.cliVersionToApply = globalConfig.getCliVersionToApply();
-    this.customCliVersion = globalConfig.getCustomCliVersion();
+    // this.cliVersionToApply = globalConfig.getCliVersionToApply();
+    // this.customCliVersion = globalConfig.getCustomCliVersion();
+
+    if (!Strings.isNullOrEmpty(scanStep.getCliVersionToApply())) {
+      this.cliVersionToApply = scanStep.getCliVersionToApply();
+    } else {
+      this.cliVersionToApply = globalConfig.getCliVersionToApply();
+    }
+
+    if (!Strings.isNullOrEmpty(scanStep.getCustomCliVersion())) {
+      this.customCliVersion = scanStep.getCustomCliVersion();
+    } else {
+      this.customCliVersion = globalConfig.getCustomCliVersion();
+    }
 
     if (!Strings.isNullOrEmpty(scanStep.getScannerBinaryPath())) {
       this.scannerBinaryPath = scanStep.getScannerBinaryPath();

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder.java
@@ -55,7 +55,7 @@ public class NewEngineBuilder extends Builder implements SimpleBuildStep, NewEng
   private boolean engineVerify = SysdigBuilder.DescriptorImpl.DEFAULT_ENGINE_VERIFY;
   private String inlineScanExtraParams = SysdigBuilder.DescriptorImpl.EMPTY_STRING;
   private String policiesToApply = "";
-  private String cliVersionToApply = "";
+  // private String cliVersionToApply = "";
   private String scannerBinaryPath = SysdigBuilder.DescriptorImpl.EMPTY_STRING;
 
 
@@ -79,10 +79,10 @@ public class NewEngineBuilder extends Builder implements SimpleBuildStep, NewEng
     return policiesToApply;
   }
 
-  @Override
-  public String getCliVersionToApply() {
-    return cliVersionToApply;
-  }
+  // @Override
+  // public String getCliVersionToApply() {
+  //   return cliVersionToApply;
+  // }
 
   @Override
   public String getEngineURL() {
@@ -127,11 +127,11 @@ public class NewEngineBuilder extends Builder implements SimpleBuildStep, NewEng
     this.policiesToApply = policiesToApply;
   }
 
-  @DataBoundSetter
-  @Override
-  public void setCliVersionToApply(String cliVersionToApply) {
-    this.cliVersionToApply = cliVersionToApply;
-  }
+  // @DataBoundSetter
+  // @Override
+  // public void setCliVersionToApply(String cliVersionToApply) {
+  //   this.cliVersionToApply = cliVersionToApply;
+  // }
 
   @DataBoundSetter
   @Override

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder.java
@@ -55,6 +55,7 @@ public class NewEngineBuilder extends Builder implements SimpleBuildStep, NewEng
   private boolean engineVerify = SysdigBuilder.DescriptorImpl.DEFAULT_ENGINE_VERIFY;
   private String inlineScanExtraParams = SysdigBuilder.DescriptorImpl.EMPTY_STRING;
   private String policiesToApply = "";
+  private String cliVersionToApply = "";
   private String scannerBinaryPath = SysdigBuilder.DescriptorImpl.EMPTY_STRING;
 
 
@@ -76,6 +77,11 @@ public class NewEngineBuilder extends Builder implements SimpleBuildStep, NewEng
   @Override
   public String getPoliciesToApply() {
     return policiesToApply;
+  }
+
+  @Override
+  public String getCliVersionToApply() {
+    return cliVersionToApply;
   }
 
   @Override
@@ -119,6 +125,12 @@ public class NewEngineBuilder extends Builder implements SimpleBuildStep, NewEng
   @Override
   public void setPoliciesToApply(String policiesToApply) {
     this.policiesToApply = policiesToApply;
+  }
+
+  @DataBoundSetter
+  @Override
+  public void setCliVersionToApply(String cliVersionToApply) {
+    this.cliVersionToApply = cliVersionToApply;
   }
 
   @DataBoundSetter

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder.java
@@ -55,7 +55,8 @@ public class NewEngineBuilder extends Builder implements SimpleBuildStep, NewEng
   private boolean engineVerify = SysdigBuilder.DescriptorImpl.DEFAULT_ENGINE_VERIFY;
   private String inlineScanExtraParams = SysdigBuilder.DescriptorImpl.EMPTY_STRING;
   private String policiesToApply = "";
-  // private String cliVersionToApply = "";
+  private String cliVersionToApply = "";
+  private String customCliVersion = "";
   private String scannerBinaryPath = SysdigBuilder.DescriptorImpl.EMPTY_STRING;
 
 
@@ -79,10 +80,15 @@ public class NewEngineBuilder extends Builder implements SimpleBuildStep, NewEng
     return policiesToApply;
   }
 
-  // @Override
-  // public String getCliVersionToApply() {
-  //   return cliVersionToApply;
-  // }
+  @Override
+  public String getCliVersionToApply() {
+    return cliVersionToApply;
+  }
+
+  @Override
+  public String getCustomCliVersion() {
+    return customCliVersion;
+  }
 
   @Override
   public String getEngineURL() {
@@ -127,11 +133,17 @@ public class NewEngineBuilder extends Builder implements SimpleBuildStep, NewEng
     this.policiesToApply = policiesToApply;
   }
 
-  // @DataBoundSetter
-  // @Override
-  // public void setCliVersionToApply(String cliVersionToApply) {
-  //   this.cliVersionToApply = cliVersionToApply;
-  // }
+  @DataBoundSetter
+  @Override
+  public void setCliVersionToApply(String cliVersionToApply) {
+    this.cliVersionToApply = cliVersionToApply;
+  }
+
+  @DataBoundSetter
+  @Override
+  public void setCustomCliVersion(String customCliVersion) {
+    this.customCliVersion = customCliVersion;
+  }
 
   @DataBoundSetter
   @Override

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineScanStep.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineScanStep.java
@@ -13,6 +13,8 @@ public interface NewEngineScanStep {
 
   String getPoliciesToApply();
 
+  String getCliVersionToApply();
+
   String getEngineURL();
 
   String getEngineCredentialsId();
@@ -31,6 +33,9 @@ public interface NewEngineScanStep {
 
   @DataBoundSetter
   void setPoliciesToApply(String policiesToApply);
+
+  @DataBoundSetter
+  void setCliVersionToApply(String cliVersionToApply);
 
   @DataBoundSetter
   void setEngineURL(String engineurl);

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineScanStep.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineScanStep.java
@@ -13,7 +13,9 @@ public interface NewEngineScanStep {
 
   String getPoliciesToApply();
 
-  // String getCliVersionToApply();
+  String getCliVersionToApply();
+
+  String getCustomCliVersion();
 
   String getEngineURL();
 
@@ -34,8 +36,11 @@ public interface NewEngineScanStep {
   @DataBoundSetter
   void setPoliciesToApply(String policiesToApply);
 
-  // @DataBoundSetter
-  // void setCliVersionToApply(String cliVersionToApply);
+  @DataBoundSetter
+  void setCliVersionToApply(String cliVersionToApply);
+
+  @DataBoundSetter
+  void setCustomCliVersion(String customCliVersion);
 
   @DataBoundSetter
   void setEngineURL(String engineurl);

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineScanStep.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineScanStep.java
@@ -13,7 +13,7 @@ public interface NewEngineScanStep {
 
   String getPoliciesToApply();
 
-  String getCliVersionToApply();
+  // String getCliVersionToApply();
 
   String getEngineURL();
 
@@ -34,8 +34,8 @@ public interface NewEngineScanStep {
   @DataBoundSetter
   void setPoliciesToApply(String policiesToApply);
 
-  @DataBoundSetter
-  void setCliVersionToApply(String cliVersionToApply);
+  // @DataBoundSetter
+  // void setCliVersionToApply(String cliVersionToApply);
 
   @DataBoundSetter
   void setEngineURL(String engineurl);

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineStep.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineStep.java
@@ -43,10 +43,10 @@ public class NewEngineStep extends Step implements BuildStep, NewEngineScanStep 
     return builder.getPoliciesToApply();
   }
 
-  @Override
-  public String getCliVersionToApply() {
-    return builder.getCliVersionToApply();
-  }
+  // @Override
+  // public String getCliVersionToApply() {
+  //   return builder.getCliVersionToApply();
+  // }
 
 
   @Override
@@ -86,11 +86,11 @@ public class NewEngineStep extends Step implements BuildStep, NewEngineScanStep 
     builder.setPoliciesToApply(policiesToApply);
   }
 
-  @DataBoundSetter
-  @Override
-  public void setCliVersionToApply(String cliVersionToApply) {
-    builder.setCliVersionToApply(cliVersionToApply);
-  }
+  // @DataBoundSetter
+  // @Override
+  // public void setCliVersionToApply(String cliVersionToApply) {
+  //   builder.setCliVersionToApply(cliVersionToApply);
+  // }
 
 
   @DataBoundSetter

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineStep.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineStep.java
@@ -103,7 +103,6 @@ public class NewEngineStep extends Step implements BuildStep, NewEngineScanStep 
     builder.setCustomCliVersion(customCliVersion);
   }
 
-
   @DataBoundSetter
   @Override
   public void setBailOnPluginFail(boolean bailOnPluginFail) {

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineStep.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineStep.java
@@ -43,6 +43,11 @@ public class NewEngineStep extends Step implements BuildStep, NewEngineScanStep 
     return builder.getPoliciesToApply();
   }
 
+  @Override
+  public String getCliVersionToApply() {
+    return builder.getCliVersionToApply();
+  }
+
 
   @Override
   public String getEngineURL() {
@@ -79,6 +84,12 @@ public class NewEngineStep extends Step implements BuildStep, NewEngineScanStep 
   @Override
   public void setPoliciesToApply(String policiesToApply) {
     builder.setPoliciesToApply(policiesToApply);
+  }
+
+  @DataBoundSetter
+  @Override
+  public void setCliVersionToApply(String cliVersionToApply) {
+    builder.setCliVersionToApply(cliVersionToApply);
   }
 
 

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineStep.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/NewEngineStep.java
@@ -43,10 +43,15 @@ public class NewEngineStep extends Step implements BuildStep, NewEngineScanStep 
     return builder.getPoliciesToApply();
   }
 
-  // @Override
-  // public String getCliVersionToApply() {
-  //   return builder.getCliVersionToApply();
-  // }
+  @Override
+  public String getCliVersionToApply() {
+    return builder.getCliVersionToApply();
+  }
+
+  @Override
+  public String getCustomCliVersion() {
+    return builder.getCustomCliVersion();
+  }
 
 
   @Override
@@ -86,11 +91,17 @@ public class NewEngineStep extends Step implements BuildStep, NewEngineScanStep 
     builder.setPoliciesToApply(policiesToApply);
   }
 
-  // @DataBoundSetter
-  // @Override
-  // public void setCliVersionToApply(String cliVersionToApply) {
-  //   builder.setCliVersionToApply(cliVersionToApply);
-  // }
+  @DataBoundSetter
+  @Override
+  public void setCliVersionToApply(String cliVersionToApply) {
+    builder.setCliVersionToApply(cliVersionToApply);
+  }
+
+  @DataBoundSetter
+  @Override
+  public void setCustomCliVersion(String customCliVersion) {
+    builder.setCustomCliVersion(customCliVersion);
+  }
 
 
   @DataBoundSetter

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder.java
@@ -227,6 +227,8 @@ public class SysdigBuilder extends Builder implements SimpleBuildStep, SysdigSca
     private String inlinescanimage = "";
     private boolean forceinlinescan = false;
     private boolean forceNewEngine = false;
+    private String cliVersionToApply = "";
+    private String customCliVersion = "";
 
 
     private String scannerBinaryPath = EMPTY_STRING;
@@ -242,6 +244,14 @@ public class SysdigBuilder extends Builder implements SimpleBuildStep, SysdigSca
 
     public void setDebug(boolean debug) {
       this.debug = debug;
+    }
+
+    public void setCliVersionToApply(String cliVersionToApply) {
+      this.cliVersionToApply = cliVersionToApply;
+    }
+
+    public void setCustomCliVersion(String customCliVersion) {
+      this.customCliVersion = customCliVersion;
     }
 
     public void setEngineurl(String engineurl) {
@@ -289,6 +299,14 @@ public class SysdigBuilder extends Builder implements SimpleBuildStep, SysdigSca
 
     public boolean getDebug() {
       return debug;
+    }
+
+    public String getCliVersionToApply() {
+      return cliVersionToApply;
+    }
+
+    public String getCustomCliVersion() {
+      return customCliVersion;
     }
 
     public String getEngineurl() {

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
@@ -268,7 +268,6 @@ public class NewEngineRemoteExecutor implements Callable<String, Exception>, Ser
     } else {
       try {
         String latestVersion = getInlineScanVersion();
-        logger.logInfo("Passed value ###: " + this.config.getCliVersionToApply());
         logger.logInfo("Downloading inlinescan v" + latestVersion);
         scannerBinaryPath = downloadInlineScan(latestVersion);
         logger.logInfo("Inlinescan binary downloaded to " + scannerBinaryPath.getPath());

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
@@ -201,8 +201,16 @@ public class NewEngineRemoteExecutor implements Callable<String, Exception>, Ser
   }
 
   private String getInlineScanPinnedVersion() {
-    logger.logInfo("Version being passed $$$$$$$$" + this.config.getCliVersionToApply());
-    return this.config.getCliVersionToApply();
+    return FIXED_SCANNED_VERSION;
+  }
+
+  private String getInlineScanVersion() throws IOException {
+   if(this.config.getCliVersionToApply().equals("latest")){
+      return getInlineScanLatestVersion();
+    } else if(this.config.getCliVersionToApply().equals("custom")){
+      return this.config.getCustomCliVersion();
+    }
+    return getInlineScanPinnedVersion();
   }
 
   private Proxy getHttpProxy() throws IOException {
@@ -256,7 +264,8 @@ public class NewEngineRemoteExecutor implements Callable<String, Exception>, Ser
       logger.logInfo("Inlinescan binary globally defined to* " + scannerBinaryPath.getPath());
     } else {
       try {
-        String latestVersion = getInlineScanPinnedVersion();
+        String latestVersion = getInlineScanVersion();
+        logger.logInfo("Passed value ###: " + this.config.getCliVersionToApply());
         logger.logInfo("Downloading inlinescan v" + latestVersion);
         scannerBinaryPath = downloadInlineScan(latestVersion);
         logger.logInfo("Inlinescan binary downloaded to " + scannerBinaryPath.getPath());

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
@@ -208,6 +208,9 @@ public class NewEngineRemoteExecutor implements Callable<String, Exception>, Ser
    if(this.config.getCliVersionToApply().equals("latest")){
       return getInlineScanLatestVersion();
     } else if(this.config.getCliVersionToApply().equals("custom")){
+      if(this.config.getCustomCliVersion().isEmpty()){
+        return getInlineScanPinnedVersion();
+      }
       return this.config.getCustomCliVersion();
     }
     return getInlineScanPinnedVersion();

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
@@ -205,9 +205,7 @@ public class NewEngineRemoteExecutor implements Callable<String, Exception>, Ser
   }
 
   private String getInlineScanVersion() throws IOException {
-   if(this.config.getCliVersionToApply().equals("latest")){
-      return getInlineScanLatestVersion();
-    } else if(this.config.getCliVersionToApply().equals("custom")){
+    if(this.config.getCliVersionToApply().equals("custom")){
       if(this.config.getCustomCliVersion().isEmpty()){
         return getInlineScanPinnedVersion();
       }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
@@ -201,7 +201,8 @@ public class NewEngineRemoteExecutor implements Callable<String, Exception>, Ser
   }
 
   private String getInlineScanPinnedVersion() {
-    return FIXED_SCANNED_VERSION;
+    logger.logInfo("Version being passed $$$$$$$$" + this.config.getCliVersionToApply());
+    return this.config.getCliVersionToApply();
   }
 
   private Proxy getHttpProxy() throws IOException {

--- a/src/main/resources/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder/config.jelly
+++ b/src/main/resources/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder/config.jelly
@@ -15,6 +15,10 @@
       <f:checkbox name="bailOnPluginFail" checked="${instance.bailOnPluginFail}" title="Fail build on critical plugin error" default="${descriptor.DEFAULT_BAIL_ON_PLUGIN_FAIL}"/>
     </f:entry>
 
+    <f:entry title="CLI version to use" field="cliVersionToApply">
+      <f:textbox/>
+    </f:entry>
+
     <f:entry title="Identifiers of policies to apply" field="policiesToApply">
       <f:textbox/>
     </f:entry>

--- a/src/main/resources/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder/config.jelly
+++ b/src/main/resources/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder/config.jelly
@@ -15,10 +15,6 @@
       <f:checkbox name="bailOnPluginFail" checked="${instance.bailOnPluginFail}" title="Fail build on critical plugin error" default="${descriptor.DEFAULT_BAIL_ON_PLUGIN_FAIL}"/>
     </f:entry>
 
-    <f:entry title="CLI version to use" field="cliVersionToApply">
-      <f:textbox/>
-    </f:entry>
-
     <f:entry title="Identifiers of policies to apply" field="policiesToApply">
       <f:textbox/>
     </f:entry>

--- a/src/main/resources/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder/config.jelly
+++ b/src/main/resources/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder/config.jelly
@@ -38,9 +38,25 @@
     <f:entry title="Extra parameters for inlinescan execution" field="inlineScanExtraParams">
       <f:textbox default=""/>
     </f:entry>
+    
     <f:entry title="Scanner binary path" field="scannerBinaryPath" help="/plugin/sysdig-secure/help/help-OverrideScannerBinaryPath.html">
       <f:textbox/>
     </f:entry>
+
+    <f:section title="Advanced Image Scanning Options">
+      <f:advanced>
+        <f:entry title="Sysdig Secure CLI Version To Use" field="cliVersionToApply" description="WARNING: Using latest or custom versions of the CLI may result in failures due to compatibility issues. Use at your own risk!" help="/plugin/sysdig-secure/help/help-CliVersionToApply.html">
+              <f:radio name="cliVersionToApply" title="Default Version" value="default"
+                checked="${instance.cliVersionToApply == 'default'}" />
+              <f:radio name="cliVersionToApply" title="Latest Version" value="latest"
+                checked="${instance.cliVersionToApply == 'latest'}" />
+              <f:radio name="cliVersionToApply" title="Custom Version" value="custom"
+            checked="${instance.cliVersionToApply == 'custom'}">
+                <f:textbox name="customCliVersion" field="customCliVersion"/>
+              </f:radio>
+        </f:entry>
+      </f:advanced>
+    </f:section>
 
   </f:section>
 </j:jelly>

--- a/src/main/resources/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder/config.jelly
+++ b/src/main/resources/com/sysdig/jenkins/plugins/sysdig/NewEngineBuilder/config.jelly
@@ -45,12 +45,10 @@
 
     <f:section title="Advanced Image Scanning Options">
       <f:advanced>
-        <f:entry title="Sysdig Secure CLI Version To Use" field="cliVersionToApply" description="WARNING: Using latest or custom versions of the CLI may result in failures due to compatibility issues. Use at your own risk!" help="/plugin/sysdig-secure/help/help-CliVersionToApply.html">
-              <f:radio name="cliVersionToApply" title="Default Version" value="default"
-                checked="${instance.cliVersionToApply == 'default'}" />
-              <f:radio name="cliVersionToApply" title="Latest Version" value="latest"
-                checked="${instance.cliVersionToApply == 'latest'}" />
-              <f:radio name="cliVersionToApply" title="Custom Version" value="custom"
+        <f:entry title="Sysdig Secure CLI Version To Use" field="cliVersionToApply" description="WARNING: Using custom versions of the CLI may result in failures due to compatibility issues. Use at your own risk!" help="/plugin/sysdig-secure/help/help-OverrideCliVersionToApply.html">
+              <f:radio name="cliVersionToApply" title="Use global setting" value="global_default"
+                checked="true" />
+              <f:radio name="cliVersionToApply" title="Override global version setting" value="custom"
             checked="${instance.cliVersionToApply == 'custom'}">
                 <f:textbox name="customCliVersion" field="customCliVersion"/>
               </f:radio>

--- a/src/main/resources/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder/global.jelly
+++ b/src/main/resources/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder/global.jelly
@@ -23,11 +23,9 @@
       <f:textbox name="inlineScanExtraParams" default=""/>
     </f:entry>
 
-    <f:entry title="Sysdig Secure CLI Version To Use" field="cliVersionToApply" description="WARNING: Using latest or custom versions of the CLI may result in failures due to compatibility issues. Use at your own risk!" help="/plugin/sysdig-secure/help/help-CliVersionToApply.html">
+    <f:entry title="Sysdig Secure CLI Version To Use" field="cliVersionToApply" description="WARNING: Using custom versions of the CLI may result in failures due to compatibility issues. Use at your own risk!" help="/plugin/sysdig-secure/help/help-CliVersionToApply.html">
           <f:radio name="cliVersionToApply" title="Default Version" value="default"
-            checked="${instance.cliVersionToApply == 'default'}" />
-          <f:radio name="cliVersionToApply" title="Latest Version" value="latest"
-            checked="${instance.cliVersionToApply == 'latest'}" />
+            checked="true" />
           <f:radio name="cliVersionToApply" title="Custom Version" value="custom"
         checked="${instance.cliVersionToApply == 'custom'}">
             <f:textbox name="customCliVersion" field="customCliVersion"/>

--- a/src/main/resources/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder/global.jelly
+++ b/src/main/resources/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder/global.jelly
@@ -23,6 +23,18 @@
       <f:textbox name="inlineScanExtraParams" default=""/>
     </f:entry>
 
+    <f:entry title="Sysdig Secure CLI Version To Use" field="cliVersionToApply" description="Specify which version of secure cli to use. 
+    WARNING: Using latest or custom versions of cli may result in failures due to compatibility issues. Use at your own risk!">
+          <f:radio name="cliVersionToApply" title="Default Version" value="default"
+            checked="${instance.cliVersionToApply == 'default'}" />
+          <f:radio name="cliVersionToApply" title="Latest Version" value="latest"
+            checked="${instance.cliVersionToApply == 'latest'}" />
+          <f:radio name="cliVersionToApply" title="Custom Version" value="custom"
+        checked="${(instance == null) ? 'true' : instance.cliVersionToApply == 'custom'}">
+            <f:textbox name="customCliVersion" field="customCliVersion" help="/plugin/sysdig-secure/help/help-CliVersionToApply.html"/>
+          </f:radio>
+    </f:entry>
+
     <f:entry title="Enable DEBUG logging" field="debug">
       <f:checkbox name="debug" checked="${descriptor.debug}" default="${false}"/>
     </f:entry>

--- a/src/main/resources/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder/global.jelly
+++ b/src/main/resources/com/sysdig/jenkins/plugins/sysdig/SysdigBuilder/global.jelly
@@ -23,15 +23,14 @@
       <f:textbox name="inlineScanExtraParams" default=""/>
     </f:entry>
 
-    <f:entry title="Sysdig Secure CLI Version To Use" field="cliVersionToApply" description="Specify which version of secure cli to use. 
-    WARNING: Using latest or custom versions of cli may result in failures due to compatibility issues. Use at your own risk!">
+    <f:entry title="Sysdig Secure CLI Version To Use" field="cliVersionToApply" description="WARNING: Using latest or custom versions of the CLI may result in failures due to compatibility issues. Use at your own risk!" help="/plugin/sysdig-secure/help/help-CliVersionToApply.html">
           <f:radio name="cliVersionToApply" title="Default Version" value="default"
             checked="${instance.cliVersionToApply == 'default'}" />
           <f:radio name="cliVersionToApply" title="Latest Version" value="latest"
             checked="${instance.cliVersionToApply == 'latest'}" />
           <f:radio name="cliVersionToApply" title="Custom Version" value="custom"
-        checked="${(instance == null) ? 'true' : instance.cliVersionToApply == 'custom'}">
-            <f:textbox name="customCliVersion" field="customCliVersion" help="/plugin/sysdig-secure/help/help-CliVersionToApply.html"/>
+        checked="${instance.cliVersionToApply == 'custom'}">
+            <f:textbox name="customCliVersion" field="customCliVersion"/>
           </f:radio>
     </f:entry>
 

--- a/src/main/webapp/help/help-CliVersionToApply.html
+++ b/src/main/webapp/help/help-CliVersionToApply.html
@@ -1,0 +1,4 @@
+<div>
+    Specifies which sysdig-cli-scanner version to use for scanning container images. If no version is specified, 
+    the default version will be used.
+</div>

--- a/src/main/webapp/help/help-CliVersionToApply.html
+++ b/src/main/webapp/help/help-CliVersionToApply.html
@@ -1,5 +1,4 @@
 <div>
     Allows for overriding the default Sysdig CLI scanner version. The Default option will use the version the plugin was
-    tested against. The Latest option will use the latest available version. Custom will allow you to specify a specific
-    version to use.
+    tested against. Custom will allow you to specify a specific version to use.
 </div>

--- a/src/main/webapp/help/help-CliVersionToApply.html
+++ b/src/main/webapp/help/help-CliVersionToApply.html
@@ -1,4 +1,5 @@
 <div>
-    Specifies which sysdig-cli-scanner version to use for scanning container images. If no version is specified, 
-    the default version will be used.
+    Allows for overriding the default Sysdig CLI scanner version. The Default option will use the version the plugin was
+    tested against. The Latest option will use the latest available version. Custom will allow you to specify a specific
+    version to use.
 </div>

--- a/src/main/webapp/help/help-OverrideCliVersionToApply.html
+++ b/src/main/webapp/help/help-OverrideCliVersionToApply.html
@@ -1,0 +1,6 @@
+<div>
+    Allows for overriding the default Sysdig CLI scanner version. 
+    The "Use global setting" option will use the version specified in the global settings. 
+    The "Override global version setting" will allow you to override global version setting and 
+    set a specific version to use.
+</div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Allow users to set sysdig secure cli version when scanning container images
- [x] Link to relevant issues in GitHub or Jira: https://sysdig.atlassian.net/browse/SSPROD-19119
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
