### PR TITLE
chore: update embedded scanner to 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>sysdig-secure</artifactId>
-  <version>2.2.10-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Sysdig Secure Container Image Scanner Plugin</name>
   <description>Integrates Jenkins with the Sysdig Secure Image Scanner to scan OCI images</description>

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 public class NewEngineRemoteExecutor implements Callable<String, Exception>, Serializable {
 
-  private static final String FIXED_SCANNED_VERSION = "1.3.6";
+  private static final String FIXED_SCANNED_VERSION = "1.5.0";
 
   public static class LogsFileToLoggerForwarder extends TailerListenerAdapter {
 


### PR DESCRIPTION
Updates the embedded scanner to latest `1.5.0` version: this will also enable scans to appear in **VM Dashboards**.