### PR TITLE
fix(style): resolved css collision with basic theme of new jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>sysdig-secure</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Sysdig Secure Container Image Scanner Plugin</name>
   <description>Integrates Jenkins with the Sysdig Secure Image Scanner to scan OCI images</description>

--- a/src/main/webapp/css/sysdig.css
+++ b/src/main/webapp/css/sysdig.css
@@ -1,3 +1,11 @@
+html, body {
+    font-size: initial;
+}
+
+.page-header {
+    margin: 0;
+}
+
 div.image-id {
     font-size: 0.8em;
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

There was some collision with CSS as the plugin loaded Bootstrap, which is used to render the table and other information. Bootstrap CSS also includes some basic styles at HTML and body levels. The new Jenkins theme in the latest version uses `rem` for the font size, and it stands for root em, which is a measurement unit that refers to the font size of the root element of a document.

So, when loading Bootstrap, it changes the root element font size. With this fix, we are saying to use the initial value of the page and remove the fixed font size

We also removed the margin for the class `page-header` that is also used by the Jenkins theme and was already styled correctly

<img width="1569" alt="Screenshot 2024-01-17 at 18 18 58" src="https://github.com/jenkinsci/sysdig-secure-plugin/assets/4377202/11ffd1d8-17a8-4026-8d1f-baac2fe4c2ef">



```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
