### PR TITLE
feat: Support ARM64 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ interface (`Sysdig Secure Report (FAIL)` in the image above)
 Use docker to build the sysdig-secure.hpi file:
 
 ```sh
-docker run -it --rm --name maven-jenkins-builder -v "$(pwd)":/usr/src/app -w /usr/src/app maven:3.3-jdk-8 mvn package
+docker run -it --rm --name maven-jenkins-builder -v "$(pwd)":/usr/src/app -w /usr/src/app maven:3.6.3-jdk-8 mvn package
 ```
 
 You can then install the plugin via the Jenkins UI, or by copying it into $JENKINS_HOME/plugins.

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/scanner/NewEngineRemoteExecutor.java
@@ -160,7 +160,8 @@ public class NewEngineRemoteExecutor implements Callable<String, Exception>, Ser
     logger.logInfo(System.getProperty("os.name"));
 
     String os = System.getProperty("os.name").toLowerCase().startsWith("mac") ? "darwin" : "linux";
-    URL url = new URL("https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/" + latestVersion + "/" + os + "/amd64/sysdig-cli-scanner");
+    String arch = System.getProperty("os.arch").toLowerCase().startsWith("aarch64") ? "arm64" : "amd64";
+    URL url = new URL("https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/" + latestVersion + "/" + os + "/" + arch + "/sysdig-cli-scanner");
     Proxy proxy = getHttpProxy();
     boolean proxyException = Arrays.asList(noProxy).contains("sysdig.com") || Arrays.asList(noProxy).contains("download.sysdig.com");
     int downloadRetriesLeft = 5;


### PR DESCRIPTION
This is a change that introduce the possibility to download the arm64 binary when running the Jenkins Agent on arm platform (ex: AWS Graviton EC2's).

I have updated on `README.md` the image tag to be used for building the plugin with maven otherwise with 3.3 image was giving errors regarding the dependencies.

### Testing done
I have built the plugin and installed on a Jenkins instance. I have build a sample pipeline that perform the scan of a given image using an AWS Graviton node as Jenkins Agent and is working:

<img width="1561" alt="Screenshot 2024-06-14 at 16 23 29" src="https://github.com/jenkinsci/sysdig-secure-plugin/assets/2905124/ee04439e-af66-4c1c-874d-dd3012888d1c">


As additional check I went inside the instance and copied the binary and confirmed that Jenkins plugin retrieved the right binary:
```
root@ip-172-31-2-1:~# cp /var/jenkins/workspace/\(Sysdig\)\ Image\ Scanning\ with\ Jenkins\ plugin\ \(pull\,\ scan\)/*/bin/inlinescan-1.10.0.bin .

root@ip-172-31-2-1:~# ./inlinescan-1.10.0.bin --version
Sysdig CLI Scanner 1.10.0
 Commit SHA:	f8ef336
 Build time:	Thu May 23 08:23:18 UTC 2024

root@ip-172-31-2-1:~# file inlinescan-1.10.0.bin
inlinescan-1.10.0.bin: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=cnmTUwvApWxXtC5xUha4/TcQaqk34KWJyXSYtohyc/xEqE0GgvbUvp3F7ffUqr/t1W38ftj9rHuI3k06i8W, stripped
```
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

