### PR TITLE
build: add nix flake to be able to compile with old graalvm

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+has nix && use flake
+dotenv_if_exists .env # You can create a .env file with your env vars for this project. You can also use .secrets if you are using act. See the line below.
+dotenv_if_exists .secrets # Used by [act](https://nektosact.com/) to load secrets into the pipelines

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ work/
 .factorypath
 .project
 .settings/
+
+# Direnv
+.direnv/
+
+# Nix Derivation result
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1724395761,
+        "narHash": "sha256-zRkDV/nbrnp3Y8oCADf5ETl1sDrdmAW6/bBVJ8EbIdQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ae815cee91b417be55d43781eb4b73ae1ecc396c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-graalvm8": {
+      "locked": {
+        "lastModified": 1633366962,
+        "narHash": "sha256-cz7etM6jjF9IKFopdHOU+jO8I33SnfDFQhOJRdELYlA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3109ff5765505dbe1f7f2905ed3f54c62bd0acaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3109ff5765505dbe1f7f2905ed3f54c62bd0acaa",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-graalvm8": "nixpkgs-graalvm8"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  description = "Sysdig Secure Plugin for Jenkins";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-graalvm8.url = "github:NixOS/nixpkgs/3109ff5765505dbe1f7f2905ed3f54c62bd0acaa";
+  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nixpkgs-graalvm8,
+    }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      setJavaVersion = final: prev: {
+        # We need to use a very old version of GraalVM 8 (from 2021-10-04), otherwise the plugin
+        # does not pass the tests and does not compile with `release:prepare` and `release:perform`.
+        jdk = graalvm8ForSystem prev.system;
+        jdt-language-server = prev.jdt-language-server.override { jdk = prev.jdk; };
+      };
+
+      graalvm8ForSystem = system: (import nixpkgs-graalvm8 { inherit system; }).graalvm8-ce;
+
+      forEachSystem =
+        f:
+        nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          let
+            pkgs = import nixpkgs {
+              inherit system;
+              overlays = [
+                setJavaVersion
+                self.overlays.default
+              ];
+            };
+          in
+          f pkgs
+        );
+    in
+    {
+      overlays.default = final: prev: { plugin = final.pkgs.callPackage ./plugin.nix { }; };
+
+      packages = forEachSystem (
+        pkgs: with pkgs; {
+          inherit plugin;
+          default = plugin;
+        }
+      );
+      devShells = forEachSystem (
+        pkgs: with pkgs; {
+          default = mkShell {
+            buildInputs = [
+              jdt-language-server
+              maven
+              jdk
+            ];
+          };
+        }
+      );
+
+      formatter = forEachSystem (pkgs: pkgs.nixfmt-rfc-style);
+    };
+}

--- a/plugin.nix
+++ b/plugin.nix
@@ -1,0 +1,14 @@
+{ maven }:
+
+maven.buildMavenPackage {
+  pname = "sysdig-secure-plugin";
+  version = "2.3.4-SNAPSHOT";
+  src = ./.;
+  mvnHash = "sha256-KYXoEdHTkW3KAGJuFQ6bjjq5xKDXoViioVwWuuptS0c=";
+
+  doCheck = false;
+  installPhase = "
+    install -Dm644 target/sysdig-secure.hpi -t $out
+    install -Dm644 target/sysdig-secure.jar -t $out
+  ";
+}


### PR DESCRIPTION
This adds a nix flake to pin the JDK version to an old GraalVM 8 from 2021 by executing `nix develop`. It's required for the plugin to properly run the tests and release with `mvn release:prepare release:perform`.
Also, running `nix build` will compile the current version of the plugin with the proper JVM and output the results into `./result/sysdig-secure.hpi` and `./result/sysdig-secure.jar` so we can test it in a Jenkins instance.