### PR TITLE
ci: add codeowners file for automatic review request

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mateobur @Jujuyeh @pabloopez @tembleking


### PR DESCRIPTION
Adds the CODEOWNERS file so we can automatically get requests on PRs opened.