### PR TITLE
fix: use imageID instead of imageDigest and update to 1.22.1

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/application/vm/report/PolicyReportProcessor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/application/vm/report/PolicyReportProcessor.java
@@ -256,7 +256,7 @@ public class PolicyReportProcessor implements ReportProcessor {
 
   private PolicyEvaluationReportLine getFailure(String failure, ImageScanningResult imageResult, String policyName, String ruleString, String ruleName) {
     return new PolicyEvaluationReportLine(
-      imageResult.getImageDigest(),
+      imageResult.getImageID(),
       imageResult.getTag(),
       "trigger_id",
       ruleName,

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/domain/vm/ImageScanningResult.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/domain/vm/ImageScanningResult.java
@@ -21,7 +21,6 @@ import com.sysdig.jenkins.plugins.sysdig.domain.vm.report.PolicyEvaluation;
 import com.sysdig.jenkins.plugins.sysdig.domain.vm.report.Result;
 
 import java.io.Serializable;
-import java.nio.file.NoSuchFileException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Stream;
@@ -41,14 +40,14 @@ public class ImageScanningResult implements Serializable {
   }
 
   private final String tag;
-  private final String imageDigest;
+  private final String imageID;
   private final String evalStatus;
   private final List<Package> packages;
   private final List<PolicyEvaluation> evaluationPolicies;
 
-  public ImageScanningResult(String tag, String imageDigest, String evalStatus, List<Package> vulnsReport, List<PolicyEvaluation> evaluationPolicies) {
+  public ImageScanningResult(String tag, String imageID, String evalStatus, List<Package> vulnsReport, List<PolicyEvaluation> evaluationPolicies) {
     this.tag = tag;
-    this.imageDigest = imageDigest;
+    this.imageID = imageID;
     this.evalStatus = evalStatus;
     this.packages = vulnsReport;
     this.evaluationPolicies = evaluationPolicies;
@@ -60,8 +59,8 @@ public class ImageScanningResult implements Serializable {
 
     final String tag = metadata.getPullString()
         .orElseThrow(() -> new NoSuchElementException("pull string not found in metadata"));
-    final String imageDigest = metadata.getDigest()
-        .orElseThrow(() -> new NoSuchElementException("digest not found in metadata"));
+    final String imageID = metadata.getImageId()
+        .orElseThrow(() -> new NoSuchElementException("imageid not found in metadata"));
     final String evalStatus = result.getPolicyEvaluationsResult()
         .orElseThrow(() -> new NoSuchElementException("policy evaluations result not found in result"));
     final List<Package> packages = result.getPackages()
@@ -69,7 +68,7 @@ public class ImageScanningResult implements Serializable {
     final List<PolicyEvaluation> policies = result.getPolicyEvaluations()
         .orElseThrow(() -> new NoSuchElementException("policy evaluations not found in result"));
 
-    return new ImageScanningResult(tag, imageDigest, evalStatus, packages, policies);
+    return new ImageScanningResult(tag, imageID, evalStatus, packages, policies);
   }
 
   public String getEvalStatus() {
@@ -88,8 +87,8 @@ public class ImageScanningResult implements Serializable {
     return tag;
   }
 
-  public String getImageDigest() {
-    return imageDigest;
+  public String getImageID() {
+    return imageID;
   }
 
   public FinalAction getFinalAction() {

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/jenkins/vm/JenkinsReportStorage.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/jenkins/vm/JenkinsReportStorage.java
@@ -66,14 +66,14 @@ public class JenkinsReportStorage implements ReportStorage, AutoCloseable {
 
   @Override
   public void savePolicyReport(ImageScanningResult scanResult, PolicyEvaluationReport report) throws IOException, InterruptedException {
-    FilePath outPath = runContext.getPathFromWorkspace(jenkinsOutputDirName, String.format(POLICY_REPORT_FILENAME_FORMAT, scanResult.getImageDigest()));
+    FilePath outPath = runContext.getPathFromWorkspace(jenkinsOutputDirName, String.format(POLICY_REPORT_FILENAME_FORMAT, scanResult.getImageID()));
     logger.logDebug(String.format("Writing policy evaluation result to %s", outPath.getRemote()));
     outPath.write(GsonBuilder.build().toJson(report), String.valueOf(StandardCharsets.UTF_8));
   }
 
   @Override
   public void saveVulnerabilityReport(ImageScanningResult scanResult) throws IOException, InterruptedException {
-    FilePath outPath = runContext.getPathFromWorkspace(jenkinsOutputDirName, String.format(CVE_LISTING_FILENAME_FORMAT, scanResult.getImageDigest()));
+    FilePath outPath = runContext.getPathFromWorkspace(jenkinsOutputDirName, String.format(CVE_LISTING_FILENAME_FORMAT, scanResult.getImageID()));
     JsonObject securityJson = VulnerabilityReportProcessor.generateVulnerabilityReport(scanResult);
     logger.logDebug(String.format("Writing vulnerability report to %s", outPath.getRemote()));
     outPath.write(securityJson.toString(), String.valueOf(StandardCharsets.UTF_8));
@@ -82,7 +82,7 @@ public class JenkinsReportStorage implements ReportStorage, AutoCloseable {
 
   @Override
   public void saveRawVulnerabilityReport(ImageScanningResult scanResult) throws IOException, InterruptedException {
-    String outFilename = String.format(RAW_VULN_REPORT_FILENAME_FORMAT, scanResult.getImageDigest());
+    String outFilename = String.format(RAW_VULN_REPORT_FILENAME_FORMAT, scanResult.getImageID());
     FilePath outPath = runContext.getPathFromWorkspace(jenkinsOutputDirName, outFilename);
     logger.logDebug(String.format("Writing raw vulnerability report to %s", outPath.getRemote()));
     outPath.write(GsonBuilder.build().toJson(scanResult.getVulnerabilityReport()), String.valueOf(StandardCharsets.UTF_8));
@@ -95,8 +95,8 @@ public class JenkinsReportStorage implements ReportStorage, AutoCloseable {
       runContext.perform(new ArtifactArchiver(jenkinsOutputDirName + "/"));
 
       logger.logDebug("Setting up build results in the UI");
-      String policyReportFilename = String.format(POLICY_REPORT_FILENAME_FORMAT, scanResult.getImageDigest());
-      String cveListingFileName = String.format(CVE_LISTING_FILENAME_FORMAT, scanResult.getImageDigest());
+      String policyReportFilename = String.format(POLICY_REPORT_FILENAME_FORMAT, scanResult.getImageID());
+      String cveListingFileName = String.format(CVE_LISTING_FILENAME_FORMAT, scanResult.getImageID());
       runContext.getRun().addAction(new SysdigAction(runContext.getRun(), scanResult, jenkinsOutputDirName, policyReportFilename, policyEvaluationSummary, cveListingFileName));
     } catch (Exception e) {
       logger.logError("Failed to setup build results due to an unexpected error", e);

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/jenkins/vm/ui/SysdigAction.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/jenkins/vm/ui/SysdigAction.java
@@ -51,7 +51,7 @@ public class SysdigAction implements Action {
     this.gateStatus = scanResult.getFinalAction().toString();
     this.gateSummary = policyEvaluationSummary;
     this.imageTag = scanResult.getTag();
-    this.imageDigest = scanResult.getImageDigest().replace(':', '-');
+    this.imageDigest = scanResult.getImageID().replace(':', '-');
     this.gateOutputUrl = String.format("../artifact/%s/%s", jenkinsOutputDirName, policyReportFilename);
     this.cveListingUrl = String.format("../artifact/%s/%s", jenkinsOutputDirName, cveListingFileName);
   }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/RemoteSysdigImageScanner.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/RemoteSysdigImageScanner.java
@@ -34,7 +34,7 @@ import java.net.URL;
 
 
 public class RemoteSysdigImageScanner {
-  private static final String FIXED_SCANNED_VERSION = "1.16.1";
+  private static final String FIXED_SCANNED_VERSION = "1.22.1";
   private final ScannerPaths scannerPaths;
   private final String imageName;
   private final RetriableRemoteDownloader retriableRemoteDownloader;

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/application/ui/report/PolicyReportProcessorTest.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/application/ui/report/PolicyReportProcessorTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PolicyReportProcessorTest {
   private final PolicyReportProcessor policyReport = new PolicyReportProcessor(new NopLogger());
-  private final String imageID = "sha256:04ba374043ccd2fc5c593885c0eacddebabd5ca375f9323666f28dfd5a9710e3";
+  private final String imageID = "sha256:39286ab8a5e14aeaf5fdd6e2fac76e0c8d31a0c07224f0ee5e6be502f12e93f3";
 
   @Test
   void testPolicyEvaluationReportIsGeneratedCorrectly() throws IOException {

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/e2e/ImageScanningE2EFreestyleTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/e2e/ImageScanningE2EFreestyleTests.java
@@ -40,7 +40,7 @@ class ImageScanningE2EFreestyleTests {
 
     jenkins.assertLogContains("Using new-scanning engine", build);
     jenkins.assertLogContains("Image Name: alpine", build);
-    jenkins.assertLogContains("Downloading inlinescan v1.16.1", build);
+    jenkins.assertLogContains("Downloading inlinescan v1.22.1", build);
     jenkins.assertLogContains("--apiurl=https://secure.sysdig.com", build);
     jenkins.assertLogContains("--loglevel=info --console-log alpine", build);
     jenkins.assertLogContains("Check that the API token is provided and is valid for the specified URL.", build);

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/e2e/ImageScanningE2EPipelineTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/e2e/ImageScanningE2EPipelineTests.java
@@ -42,7 +42,7 @@ class ImageScanningE2EPipelineTests {
 
     jenkins.assertLogContains("Using new-scanning engine", build);
     jenkins.assertLogContains("Image Name: alpine", build);
-    jenkins.assertLogContains("Downloading inlinescan v1.16.1", build);
+    jenkins.assertLogContains("Downloading inlinescan v1.22.1", build);
     jenkins.assertLogContains("Check that the API token is provided and is valid for the specified URL.", build);
   }
 


### PR DESCRIPTION
Locally built images don't have a image digest, since they are not coming from a registry. This commit changes the usage of imageDigest to imageID so we can also create reports for locally built images.

This also updates the version of the CLI to 1.22.1 by default to be up-to-date with the latest changes.

Fixes #128 