### PR TITLE
build: update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,21 @@
 
-update: update-parent-pom update-dependencies
+update: update-parent-pom update-dependencies update-flake update-sysdig-cli-version
 
 update-parent-pom:
-	mvn versions:update-parent
+	mvn versions:update-parent -DgenerateBackupPoms=false
 
 update-dependencies:
 	mvn versions:use-latest-versions
 
 verify:
 	mvn clean verify javadoc:jar
+
+update-flake:
+	-nix flake update
+
+update-sysdig-cli-version:
+	@echo "Fetching latest sysdig version…"
+	@latest=$$(curl -sfSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt) && \
+	echo "Latest: $$latest" && \
+	sed -i -E 's/(private static final String FIXED_SCANNED_VERSION = ")([^"]+)(")/\1'$$latest'\3/' src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/RemoteSysdigImageScanner.java && \
+	echo "Version updated"

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725194671,
-        "narHash": "sha256-tLGCFEFTB5TaOKkpfw3iYT9dnk4awTP/q4w+ROpMfuw=",
+        "lastModified": 1750215678,
+        "narHash": "sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M+ok=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
+        "rev": "5395fb3ab3f97b9b7abca147249fa2e8ed27b192",
         "type": "github"
       },
       "original": {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.7</version>
+    <version>5.17</version>
     <relativePath />
   </parent>
 
@@ -27,7 +27,7 @@
     <!-- You can check out which versions are being used per version in https://stats.jenkins.io/pluginversions/sysdig-secure.html -->
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/mark-a-plugin-incompatible/ -->
     <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
   </properties>
@@ -39,7 +39,7 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
         <!-- You can find your version for the selected baseline in: https://repo.jenkins-ci.org/public/io/jenkins/tools/bom/ -->
-        <version>4136.vca_c3202a_7fd1</version>
+        <version>4488.v7fe26526366e</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/RemoteSysdigImageScanner.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/RemoteSysdigImageScanner.java
@@ -34,7 +34,7 @@ import java.net.URL;
 
 
 public class RemoteSysdigImageScanner {
-  private static final String FIXED_SCANNED_VERSION = "1.22.1";
+  private static final String FIXED_SCANNED_VERSION = "1.22.3";
   private final ScannerPaths scannerPaths;
   private final String imageName;
   private final RetriableRemoteDownloader retriableRemoteDownloader;

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/e2e/ImageScanningE2EFreestyleTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/e2e/ImageScanningE2EFreestyleTests.java
@@ -40,7 +40,7 @@ class ImageScanningE2EFreestyleTests {
 
     jenkins.assertLogContains("Using new-scanning engine", build);
     jenkins.assertLogContains("Image Name: alpine", build);
-    jenkins.assertLogContains("Downloading inlinescan v1.22.1", build);
+    jenkins.assertLogContains("Downloading inlinescan v1.22.3", build);
     jenkins.assertLogContains("--apiurl=https://secure.sysdig.com", build);
     jenkins.assertLogContains("--loglevel=info --console-log alpine", build);
     jenkins.assertLogContains("Check that the API token is provided and is valid for the specified URL.", build);

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/e2e/ImageScanningE2EPipelineTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/e2e/ImageScanningE2EPipelineTests.java
@@ -42,7 +42,7 @@ class ImageScanningE2EPipelineTests {
 
     jenkins.assertLogContains("Using new-scanning engine", build);
     jenkins.assertLogContains("Image Name: alpine", build);
-    jenkins.assertLogContains("Downloading inlinescan v1.22.1", build);
+    jenkins.assertLogContains("Downloading inlinescan v1.22.3", build);
     jenkins.assertLogContains("Check that the API token is provided and is valid for the specified URL.", build);
   }
 


### PR DESCRIPTION
- Updates base plugin from 5.7 to 5.17
- Updates minimum Jenkins required version from 2.479.1 to 2.479.3
- Updates base bom from 4136.vca_c3202a_7fd1 to 4488.v7fe26526366e
- Updates sysdig cli version from 1.22.1 to 1.22.3
- Updates nix flake dev dependencies
