### PR TITLE
fix: solve error deserializating status of old jobs with sysdig

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/application/vm/report/PolicyEvaluationSummaryLine.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/application/vm/report/PolicyEvaluationSummaryLine.java
@@ -15,9 +15,72 @@ limitations under the License.
 */
 package com.sysdig.jenkins.plugins.sysdig.application.vm.report;
 
-public record PolicyEvaluationSummaryLine(
+import java.util.Objects;
+
+public final class PolicyEvaluationSummaryLine {
+    private final String imageTag;
+    private final int nonWhitelistedStopActions;
+    private final int nonWhitelistedWarnActions;
+    private final int nonWhitelistedGoActions;
+    private final String finalAction;
+
+    public PolicyEvaluationSummaryLine(
         String imageTag,
         int nonWhitelistedStopActions,
         int nonWhitelistedWarnActions,
         int nonWhitelistedGoActions,
-        String finalAction) {}
+        String finalAction) {
+        this.imageTag = imageTag;
+        this.nonWhitelistedStopActions = nonWhitelistedStopActions;
+        this.nonWhitelistedWarnActions = nonWhitelistedWarnActions;
+        this.nonWhitelistedGoActions = nonWhitelistedGoActions;
+        this.finalAction = finalAction;
+    }
+
+    public String imageTag() {
+        return imageTag;
+    }
+
+    public int nonWhitelistedStopActions() {
+        return nonWhitelistedStopActions;
+    }
+
+    public int nonWhitelistedWarnActions() {
+        return nonWhitelistedWarnActions;
+    }
+
+    public int nonWhitelistedGoActions() {
+        return nonWhitelistedGoActions;
+    }
+
+    public String finalAction() {
+        return finalAction;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (PolicyEvaluationSummaryLine) obj;
+        return Objects.equals(this.imageTag, that.imageTag) &&
+            this.nonWhitelistedStopActions == that.nonWhitelistedStopActions &&
+            this.nonWhitelistedWarnActions == that.nonWhitelistedWarnActions &&
+            this.nonWhitelistedGoActions == that.nonWhitelistedGoActions &&
+            Objects.equals(this.finalAction, that.finalAction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(imageTag, nonWhitelistedStopActions, nonWhitelistedWarnActions, nonWhitelistedGoActions, finalAction);
+    }
+
+    @Override
+    public String toString() {
+        return "PolicyEvaluationSummaryLine[" +
+            "imageTag=" + imageTag + ", " +
+            "nonWhitelistedStopActions=" + nonWhitelistedStopActions + ", " +
+            "nonWhitelistedWarnActions=" + nonWhitelistedWarnActions + ", " +
+            "nonWhitelistedGoActions=" + nonWhitelistedGoActions + ", " +
+            "finalAction=" + finalAction + ']';
+    }
+}

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/jenkins/vm/ui/SysdigActionPersistenceTest.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/jenkins/vm/ui/SysdigActionPersistenceTest.java
@@ -1,0 +1,61 @@
+package com.sysdig.jenkins.plugins.sysdig.infrastructure.jenkins.vm.ui;
+
+import com.sysdig.jenkins.plugins.sysdig.TestMother;
+import com.sysdig.jenkins.plugins.sysdig.application.vm.report.PolicyEvaluationSummary;
+import com.sysdig.jenkins.plugins.sysdig.e2e.JenkinsTestHelpers;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@WithJenkins
+public class SysdigActionPersistenceTest {
+    private JenkinsRule rule;
+    private JenkinsTestHelpers helpers;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        this.rule = rule;
+        helpers = new JenkinsTestHelpers(rule);
+        helpers.configureSysdigCredentials();
+    }
+
+    @Test
+    public void itPersistsCorrectlyAndReloadsFromDisk() throws Exception {
+        var project = helpers.createFreestyleProjectWithImageScanningBuilder("freestyle")
+            .withConfig(b -> b.setEngineCredentialsId("sysdig-secure"))
+            .build();
+
+        var build = rule.buildAndAssertStatus(Result.FAILURE, project);
+        rule.waitUntilNoActivity();
+
+        var summary = new PolicyEvaluationSummary();
+        summary.addSummaryLine("ubuntu:22.04", 1, 2, 3, "STOP");
+
+        build.addAction(new SysdigAction(
+            build, TestMother.scanResultForUbuntu2204().toDomain().get(),
+            "SysdigSecureReport_11",
+            "policy.json",
+            summary,
+            "cve.json"
+        ));
+        build.save();
+
+        rule.jenkins.reload();
+
+        FreeStyleProject projectFromDisk = rule.jenkins.getItemByFullName(project.getFullName(), FreeStyleProject.class);
+        var buildLoadedFromDisk = projectFromDisk.getBuildByNumber(build.getNumber());
+        var actionLoadedFromDisk = buildLoadedFromDisk.getAction(com.sysdig.jenkins.plugins.sysdig.infrastructure.jenkins.vm.ui.SysdigAction.class);
+
+        assertEquals("Sysdig Secure Report (ubuntu:22.04) (Failed)", actionLoadedFromDisk.getDisplayName());
+        assertEquals("""
+            {"header":[{"data":"Repo_Tag","title":"Repo Tag"},{"data":"Stop_Actions","title":"Stop Actions"},{"data":"Warn_Actions","title":"Warn Actions"},{"data":"Go_Actions","title":"Go Actions"},{"data":"Final_Action","title":"Final Action"}],"rows":[{"Repo_Tag":"ubuntu:22.04","Stop_Actions":1,"Warn_Actions":2,"Go_Actions":3,"Final_Action":"STOP"}]}""", actionLoadedFromDisk.getGateSummary());
+    }
+
+}


### PR DESCRIPTION
The latest implementation of PolicyEvaluationSummaryLine being a Record broke the deserialization status of previous job executions in Jenkins that used the Sysdig Plugin. This fixes it and adds a test to avoid future regressions.