### PR TITLE
fix: NPE on scan results from cli-scanner >= 1.25.0

### DIFF
--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/domain/vm/scanresult/Package.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/domain/vm/scanresult/Package.java
@@ -1,10 +1,12 @@
 package com.sysdig.jenkins.plugins.sysdig.domain.vm.scanresult;
 
 import com.sysdig.jenkins.plugins.sysdig.domain.AggregateChild;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 public class Package implements AggregateChild<ScanResult>, Serializable {
@@ -24,7 +26,7 @@ public class Package implements AggregateChild<ScanResult>, Serializable {
             String name,
             String version,
             String path,
-            Layer foundInLayer,
+            @Nullable Layer foundInLayer,
             ScanResult root) {
         this.id = id;
         this.type = type;
@@ -57,8 +59,8 @@ public class Package implements AggregateChild<ScanResult>, Serializable {
         return path;
     }
 
-    public Layer foundInLayer() {
-        return foundInLayer;
+    public Optional<Layer> foundInLayer() {
+        return Optional.ofNullable(foundInLayer);
     }
 
     public void addVulnerabilityFound(Vulnerability vulnerability) {

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/domain/vm/scanresult/ScanResult.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/domain/vm/scanresult/ScanResult.java
@@ -54,10 +54,13 @@ public class ScanResult implements Serializable {
         return Collections.unmodifiableCollection(this.layers.values());
     }
 
-    public Package addPackage(String id, PackageType type, String name, String version, String path, Layer layer) {
+    public Package addPackage(
+            String id, PackageType type, String name, String version, String path, @Nullable Layer layer) {
         Package aPackage = new Package(id, type, name, version, path, layer, this);
         this.packages.put(id, aPackage);
-        layer.addPackage(aPackage);
+        if (layer != null) {
+            layer.addPackage(aPackage);
+        }
         return aPackage;
     }
 

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/domain/vm/scanresult/Vulnerability.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/domain/vm/scanresult/Vulnerability.java
@@ -75,7 +75,7 @@ public class Vulnerability implements AggregateChild<ScanResult>, Serializable {
     }
 
     public Set<Layer> foundInLayers() {
-        return foundInPackages.stream().map(Package::foundInLayer).collect(Collectors.toUnmodifiableSet());
+        return foundInPackages.stream().flatMap(p -> p.foundInLayer().stream()).collect(Collectors.toUnmodifiableSet());
     }
 
     @Override

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/report/v1/JsonScanResultV1.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/report/v1/JsonScanResultV1.java
@@ -93,9 +93,13 @@ public record JsonScanResultV1(JsonInfo info, JsonScanner scanner, JsonResult re
             String pkgId = entry.getKey();
             JsonPackage jsonPkg = entry.getValue();
 
+            // sysdig-cli-scanner >= 1.25.0 emits meta-packages (base OS distro, container image)
+            // without a layerRef. Keep them with a null layer so their vulnerabilities and policy
+            // failures are still reported.
             JsonLayer jsonLayer = result().layers().get(jsonPkg.layerRef());
-            var layerWhereThisPackageIsFound =
-                    scanResult.findLayerByDigest(jsonLayer.digest()).get();
+            Layer layerWhereThisPackageIsFound = jsonLayer == null
+                    ? null
+                    : scanResult.findLayerByDigest(jsonLayer.digest()).orElse(null);
 
             Package addedPackage = scanResult.addPackage(
                     pkgId,

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/TestMother.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/TestMother.java
@@ -55,4 +55,14 @@ public class TestMother {
         return GsonBuilder.build()
                 .fromJson(new InputStreamReader(imageStream, StandardCharsets.UTF_8), JsonScanResultV1.class);
     }
+
+    public static JsonScanResultV1 scanResultWithPackageWithoutLayer() {
+        String resourcePath =
+                "com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/report/v1/scanner_1.26.0_package_with_null_layer.json";
+        InputStream imageStream = TestMother.class.getClassLoader().getResourceAsStream(resourcePath);
+        assertNotNull(imageStream);
+
+        return GsonBuilder.build()
+                .fromJson(new InputStreamReader(imageStream, StandardCharsets.UTF_8), JsonScanResultV1.class);
+    }
 }

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/report/v1/JsonScanResultTest.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/report/v1/JsonScanResultTest.java
@@ -152,4 +152,18 @@ class JsonScanResultTest {
         assertTrue(scanResult.policies().stream()
                 .anyMatch(p -> p.evaluationResult().isFailed()));
     }
+
+    @Test
+    void whenAPackageHasNoLayerRefItShouldNotThrowNPE() {
+        // cli-scanner >= 1.25.0 emits meta-packages (base OS distro, container image)
+        // without a layerRef, so result().layers().get(layerRef) returns null and
+        // jsonLayer.digest() NPEs.
+        JsonScanResultV1 jsonScanResult = TestMother.scanResultWithPackageWithoutLayer();
+
+        ScanResult result = assertDoesNotThrow(() -> jsonScanResult.toDomain().get());
+
+        assertEquals(2, result.packages().size());
+        assertTrue(result.packages().stream().anyMatch(p -> p.name().equals("ubuntu")));
+        assertTrue(result.packages().stream().anyMatch(p -> p.name().equals("libcurl")));
+    }
 }

--- a/src/test/resources/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/report/v1/scanner_1.26.0_package_with_null_layer.json
+++ b/src/test/resources/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/report/v1/scanner_1.26.0_package_with_null_layer.json
@@ -1,0 +1,66 @@
+{
+  "info": {
+    "scanTime": "2025-11-20T10:00:00.000000000Z",
+    "scanDuration": "1s",
+    "resultUrl": "https://app.sysdig.com/secure/#/vulnerabilities/results/dummy/overview",
+    "resultId": "dummy"
+  },
+  "scanner": {
+    "name": "sysdig-cli-scanner",
+    "version": "1.26.0"
+  },
+  "result": {
+    "assetType": "containerImage",
+    "baseImages": {},
+    "layers": {
+      "knownLayer": {
+        "command": "/bin/sh -c #(nop) ADD file:dummy in / ",
+        "digest": "sha256:f862e1968e4b4c3c3af141e37d2ec22b19ec0fd50d6a8aaf683de6729e296226",
+        "index": 0,
+        "size": 100
+      }
+    },
+    "metadata": {
+      "architecture": "amd64",
+      "author": "",
+      "baseOs": "ubuntu 22.04",
+      "createdAt": "2025-05-30T22:30:45.500168088Z",
+      "digest": "sha256:01a3ee0b5e413cefaaffc6abe68c9c37879ae3cced56a8e088b1649e5b269eee",
+      "imageId": "sha256:b103ac8bf22ec7fe2abe740f86dccd1e7d086e0ad8d064d07bd9c8a7961a5d7a",
+      "labels": {},
+      "os": "linux",
+      "pullString": "ubuntu:22.04",
+      "size": 100
+    },
+    "packages": {
+      "os-distro-meta-package": {
+        "category": "operating-system",
+        "isRemoved": false,
+        "name": "ubuntu",
+        "type": "os",
+        "version": "22.04",
+        "vulnerabilitiesRefs": []
+      },
+      "normal-package": {
+        "isRemoved": false,
+        "irRunning": true,
+        "layerRef": "knownLayer",
+        "name": "libcurl",
+        "path": "/usr/lib/libcurl",
+        "type": "os",
+        "version": "7.74.0",
+        "vulnerabilitiesRefs": []
+      }
+    },
+    "policies": {
+      "globalEvaluation": "passed",
+      "evaluations": []
+    },
+    "producer": {
+      "producedAt": "2025-11-20T10:00:00.000000000Z"
+    },
+    "riskAccepts": {},
+    "stage": "",
+    "vulnerabilities": {}
+  }
+}


### PR DESCRIPTION
sysdig-cli-scanner 1.25.0+ emits meta-packages (base OS distro, container image) without a `layerRef`. `JsonScanResultV1.addPackagesTo` calls `result().layers().get(jsonPkg.layerRef())` which returns `null` and then NPEs on `jsonLayer.digest()`, breaking the whole report.

Keep these packages with a null layer (`Package.foundInLayer` is now `Optional<Layer>`) so their vulnerabilities and policy failures stay in the report instead of being silently dropped.