### PR TITLE
refactor: split RemoteSysdigImageScanner and enhance testing coverage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778036283,
-        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
+        "lastModified": 1781454065,
+        "narHash": "sha256-d2xfDjnfRuf/xYGdu9VVRHiav/2w5hDL/5cw2TuVAXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -59,7 +59,7 @@ update-sysdig-cli-version:
     echo "Fetching latest sysdig version…"
     latest=$(curl -sfSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
     echo "Latest: $latest"
-    sed -i -E 's/(private static final String FIXED_SCANNED_VERSION = ")([^"]+)(")/\1'"$latest"'\3/' src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/RemoteSysdigImageScanner.java
+    sed -i -E 's/(private static final String FIXED_SCANNED_VERSION = ")([^"]+)(")/\1'"$latest"'\3/' src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerVersionResolver.java
     echo "Version updated"
 
 # Run Jenkins locally with the plugin installed (http://localhost:8080/jenkins)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2111.v8b_6a_1d599df3</version>
+    <version>6.2189.v695a_c41f5249</version>
     <relativePath />
   </parent>
 
@@ -57,7 +57,7 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
         <!-- You can find your version for the selected baseline in: https://repo.jenkins-ci.org/public/io/jenkins/tools/bom/ -->
-        <version>6398.v1d26a_dd495e2</version>
+        <version>6585.va_085f4d47c41</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/http/ExecutableDownloader.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/http/ExecutableDownloader.java
@@ -1,0 +1,25 @@
+/*
+Copyright (C) 2016-2024 Sysdig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.sysdig.jenkins.plugins.sysdig.infrastructure.http;
+
+import hudson.FilePath;
+import java.io.IOException;
+import java.net.URL;
+
+/** Downloads a remote executable into the workspace and returns its path. */
+public interface ExecutableDownloader {
+    FilePath downloadExecutable(URL url, String fileName) throws IOException, InterruptedException;
+}

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/http/RemoteDownloader.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/http/RemoteDownloader.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Stream;
 
-public class RemoteDownloader {
+public class RemoteDownloader implements ExecutableDownloader {
     private final RunContext runContext;
     protected final SysdigLogger logger;
     private final EnvVars envVars;
@@ -22,6 +22,7 @@ public class RemoteDownloader {
         this.envVars = runContext.getEnvVars();
     }
 
+    @Override
     public FilePath downloadExecutable(URL url, String fileName) throws IOException, InterruptedException {
         FilePath executableFile = downloadFile(url, fileName);
 

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/RemoteSysdigImageScanner.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/RemoteSysdigImageScanner.java
@@ -15,7 +15,6 @@ limitations under the License.
 */
 package com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner;
 
-import com.google.common.base.Strings;
 import com.sysdig.jenkins.plugins.sysdig.application.vm.ImageScanningConfig;
 import com.sysdig.jenkins.plugins.sysdig.domain.SysdigLogger;
 import com.sysdig.jenkins.plugins.sysdig.domain.vm.scanresult.ScanResult;
@@ -26,30 +25,22 @@ import com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner.report.v1.JsonSc
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.FilePath;
-import java.io.IOException;
-import java.io.Serializable;
-import java.net.MalformedURLException;
-import java.net.URL;
 
 public class RemoteSysdigImageScanner {
-    private static final String FIXED_SCANNED_VERSION = "1.26.0";
     private final ScannerPaths scannerPaths;
-    private final String imageName;
-    private final RetriableRemoteDownloader retriableRemoteDownloader;
-    private final ImageScanningConfig config;
+    private final ScannerBinaryProvider binaryProvider;
+    private final ScannerExecutor executor;
     private final SysdigLogger logger;
-    private final RunContext runContext;
 
     public RemoteSysdigImageScanner(
             @NonNull RunContext runContext,
             RetriableRemoteDownloader retriableRemoteDownloader,
             String imageName,
             ImageScanningConfig config) {
-        this.runContext = runContext;
-        this.imageName = imageName;
-        this.retriableRemoteDownloader = retriableRemoteDownloader;
-        this.config = config;
         this.scannerPaths = new ScannerPaths(runContext.getPathFromWorkspace());
+        this.binaryProvider = new ScannerBinaryProvider(
+                runContext, retriableRemoteDownloader, config, new ScannerVersionResolver(config));
+        this.executor = new ScannerExecutor(runContext, config, scannerPaths, imageName);
         this.logger = runContext.getLogger();
     }
 
@@ -57,9 +48,9 @@ public class RemoteSysdigImageScanner {
         // Create all the necessary folders to store execution temp files and such
         createExecutionWorkspace();
         // Retrieve the scanner bin file
-        final FilePath scannerBinaryFile = retrieveScannerBinFile();
+        final FilePath scannerBinaryFile = binaryProvider.retrieve();
         // Execute the scanner bin file and retrieves its json output
-        String imageScanningResultJSON = executeScan(scannerBinaryFile);
+        String imageScanningResultJSON = executor.execute(scannerBinaryFile);
         logger.logDebug("Raw scan result as JSON: ");
         logger.logDebug(imageScanningResultJSON);
         JsonScanResultV1 jsonScanResult = GsonBuilder.build().fromJson(imageScanningResultJSON, JsonScanResultV1.class);
@@ -70,150 +61,12 @@ public class RemoteSysdigImageScanner {
                         String.format("unable to obtain result from scan: %s", imageScanningResultJSON)));
     }
 
-    private FilePath downloadInlineScan(String latestVersion)
-            throws IOException, UnsupportedOperationException, InterruptedException {
-        URL url = sysdigCLIScannerURLForVersion(latestVersion);
-        return retriableRemoteDownloader.downloadExecutable(url, String.format("inlinescan-%s.bin", latestVersion));
-    }
-
-    private static URL sysdigCLIScannerURLForVersion(String latestVersion) throws MalformedURLException {
-        String os = System.getProperty("os.name").toLowerCase().startsWith("mac") ? "darwin" : "linux";
-        String arch = System.getProperty("os.arch").toLowerCase().startsWith("aarch64") ? "arm64" : "amd64";
-        URL url = new URL("https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/" + latestVersion + "/" + os
-                + "/" + arch + "/sysdig-cli-scanner");
-        return url;
-    }
-
-    private String getInlineScanPinnedVersion() {
-        return FIXED_SCANNED_VERSION;
-    }
-
-    private String getInlineScanVersion() {
-        if (Strings.isNullOrEmpty(this.config.getCliVersionToApply())) {
-            return getInlineScanPinnedVersion();
-        }
-
-        if (!this.config.getCliVersionToApply().equals("custom")) {
-            return getInlineScanPinnedVersion();
-        }
-
-        if (this.config.getCustomCliVersion().isEmpty()) {
-            return getInlineScanPinnedVersion();
-        }
-
-        return this.config.getCustomCliVersion();
-    }
-
     private void createExecutionWorkspace() throws AbortException {
         try {
             this.scannerPaths.create();
         } catch (Exception e) {
             logger.logError("Unable to create scanner execution workspace", e);
             throw new AbortException("Unable to create scanner execution workspace");
-        }
-    }
-
-    private FilePath retrieveScannerBinFile() throws AbortException {
-        if (!Strings.isNullOrEmpty(config.getScannerBinaryPath())) {
-            FilePath scannerBinaryPath = runContext.getPathFromWorkspace(config.getScannerBinaryPath());
-            logger.logInfo("Inlinescan binary globally defined to* " + scannerBinaryPath.getRemote());
-            return scannerBinaryPath;
-        }
-
-        try {
-            String latestVersion = getInlineScanVersion();
-            logger.logInfo("Downloading inlinescan v" + latestVersion);
-            FilePath scannerBinaryPath = downloadInlineScan(latestVersion);
-            logger.logInfo("Inlinescan binary downloaded to " + scannerBinaryPath.getRemote());
-            return scannerBinaryPath;
-        } catch (IOException | InterruptedException e) {
-            throw new AbortException("Error downloading inlinescan binary: " + e);
-        }
-    }
-
-    private String executeScan(final FilePath scannerBinFile) throws AbortException {
-        try {
-            final FilePath scannerJsonOutputFile =
-                    this.scannerPaths.getBaseFolder().child("inlinescan.json");
-            SysdigImageScanningProcessBuilder processBuilder =
-                    createProcessBuilder(scannerBinFile, scannerJsonOutputFile);
-
-            logger.logInfo("Executing: " + String.join(" ", processBuilder.toCommandLineArguments()));
-            logger.logInfo("Waiting for scanner execution to be completed...");
-            int scannerExitCode = processBuilder.launchAndWait(this.runContext.getLauncher());
-            logger.logInfo(String.format("Scanner exit code: %d", scannerExitCode));
-
-            String jsonOutput = "";
-            if (scannerJsonOutputFile.exists()) jsonOutput = scannerJsonOutputFile.readToString();
-            logger.logDebug("Inline scan JSON output:\n" + jsonOutput);
-
-            if (scannerExitCode == 2) {
-                jsonOutput = "{error:\"Wrong parameters in call to inline scanner\"}";
-            } else if (scannerExitCode == 3) {
-                jsonOutput =
-                        "{error:\"Unexpected error when executing scan. Check that the API token is provided and is valid for the specified URL.\"}";
-            } else if (scannerExitCode != 0 && scannerExitCode != 1) {
-                throw new Exception("Cannot manage return code");
-            }
-
-            return jsonOutput;
-        } catch (Exception e) {
-            throw new AbortException("Error executing inlinescan binary: " + e);
-        }
-    }
-
-    private SysdigImageScanningProcessBuilder createProcessBuilder(
-            FilePath scannerBinFile, FilePath scannerJsonOutputFile) {
-        SysdigImageScanningProcessBuilder processBuilder = new SysdigImageScanningProcessBuilder(
-                        scannerBinFile.getRemote(), this.config.getSysdigToken())
-                .withExtraEnvVars(this.runContext.getEnvVars())
-                .withEngineURL(this.config.getEngineurl())
-                .withDBPath(this.scannerPaths.getDatabaseFolder().getRemote())
-                .withCachePath(this.scannerPaths.getCacheFolder().getRemote())
-                .withScanResultOutputPath(scannerJsonOutputFile.getRemote())
-                .withConsoleLog()
-                .withExtraParametersSeparatedBySpace(this.config.getInlineScanExtraParams())
-                .withPoliciesToApplySeparatedBySpace(this.config.getPoliciesToApply())
-                .withStdoutRedirectedTo(this.logger)
-                .withStderrRedirectedTo(this.logger)
-                .withLogLevel(
-                        config.getDebug()
-                                ? SysdigImageScanningProcessBuilder.LogLevel.DEBUG
-                                : SysdigImageScanningProcessBuilder.LogLevel.INFO)
-                .withTLSVerification(config.getEngineverify());
-
-        return processBuilder.withImageToScan(imageName);
-    }
-
-    private static class ScannerPaths implements Serializable {
-        private static final String SCANNER_EXEC_FOLDER_BASE_PATH_PATTERN = "sysdig-secure-scan-%d";
-        private final FilePath baseFolder;
-        private final FilePath databaseFolder;
-        private final FilePath cacheFolder;
-
-        public ScannerPaths(final FilePath basePath) {
-            this.baseFolder =
-                    basePath.child(String.format(SCANNER_EXEC_FOLDER_BASE_PATH_PATTERN, System.currentTimeMillis()));
-            this.databaseFolder = baseFolder.child("db");
-            this.cacheFolder = baseFolder.child("cache");
-        }
-
-        public FilePath getBaseFolder() {
-            return this.baseFolder;
-        }
-
-        public FilePath getDatabaseFolder() {
-            return this.databaseFolder;
-        }
-
-        public FilePath getCacheFolder() {
-            return this.cacheFolder;
-        }
-
-        public void create() throws Exception {
-            this.baseFolder.mkdirs();
-            this.databaseFolder.mkdirs();
-            this.cacheFolder.mkdirs();
         }
     }
 }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerBinaryProvider.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerBinaryProvider.java
@@ -1,0 +1,86 @@
+/*
+Copyright (C) 2016-2024 Sysdig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner;
+
+import com.google.common.base.Strings;
+import com.sysdig.jenkins.plugins.sysdig.application.vm.ImageScanningConfig;
+import com.sysdig.jenkins.plugins.sysdig.domain.SysdigLogger;
+import com.sysdig.jenkins.plugins.sysdig.infrastructure.http.ExecutableDownloader;
+import com.sysdig.jenkins.plugins.sysdig.infrastructure.jenkins.RunContext;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.AbortException;
+import hudson.FilePath;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Provides the Sysdig CLI scanner binary, either by resolving a user-configured
+ * path or by downloading the appropriate release for the current OS/arch.
+ */
+public class ScannerBinaryProvider {
+    private final RunContext runContext;
+    private final ExecutableDownloader downloader;
+    private final ImageScanningConfig config;
+    private final ScannerVersionResolver versionResolver;
+    private final SysdigLogger logger;
+
+    public ScannerBinaryProvider(
+            @NonNull RunContext runContext,
+            ExecutableDownloader downloader,
+            ImageScanningConfig config,
+            ScannerVersionResolver versionResolver) {
+        this.runContext = runContext;
+        this.downloader = downloader;
+        this.config = config;
+        this.versionResolver = versionResolver;
+        this.logger = runContext.getLogger();
+    }
+
+    public FilePath retrieve() throws AbortException {
+        if (!Strings.isNullOrEmpty(config.getScannerBinaryPath())) {
+            FilePath scannerBinaryPath = runContext.getPathFromWorkspace(config.getScannerBinaryPath());
+            logger.logInfo("Inlinescan binary globally defined to* " + scannerBinaryPath.getRemote());
+            return scannerBinaryPath;
+        }
+
+        try {
+            String latestVersion = versionResolver.resolve();
+            logger.logInfo("Downloading inlinescan v" + latestVersion);
+            FilePath scannerBinaryPath = download(latestVersion);
+            logger.logInfo("Inlinescan binary downloaded to " + scannerBinaryPath.getRemote());
+            return scannerBinaryPath;
+        } catch (IOException | InterruptedException e) {
+            throw new AbortException("Error downloading inlinescan binary: " + e);
+        }
+    }
+
+    private FilePath download(String version) throws IOException, UnsupportedOperationException, InterruptedException {
+        URL url = downloadURLForVersion(version);
+        return downloader.downloadExecutable(url, String.format("inlinescan-%s.bin", version));
+    }
+
+    static URL downloadURLForVersion(String version) throws MalformedURLException {
+        return downloadURLForVersion(version, System.getProperty("os.name"), System.getProperty("os.arch"));
+    }
+
+    static URL downloadURLForVersion(String version, String osName, String osArch) throws MalformedURLException {
+        String os = osName.toLowerCase().startsWith("mac") ? "darwin" : "linux";
+        String arch = osArch.toLowerCase().startsWith("aarch64") ? "arm64" : "amd64";
+        return new URL("https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/" + version + "/" + os + "/" + arch
+                + "/sysdig-cli-scanner");
+    }
+}

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerExecutor.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerExecutor.java
@@ -1,0 +1,95 @@
+/*
+Copyright (C) 2016-2024 Sysdig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner;
+
+import com.sysdig.jenkins.plugins.sysdig.application.vm.ImageScanningConfig;
+import com.sysdig.jenkins.plugins.sysdig.domain.SysdigLogger;
+import com.sysdig.jenkins.plugins.sysdig.infrastructure.jenkins.RunContext;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.AbortException;
+import hudson.FilePath;
+
+/** Runs the Sysdig CLI scanner binary and returns its raw JSON output. */
+public class ScannerExecutor {
+    private final RunContext runContext;
+    private final ImageScanningConfig config;
+    private final ScannerPaths scannerPaths;
+    private final String imageName;
+    private final SysdigLogger logger;
+
+    public ScannerExecutor(
+            @NonNull RunContext runContext, ImageScanningConfig config, ScannerPaths scannerPaths, String imageName) {
+        this.runContext = runContext;
+        this.config = config;
+        this.scannerPaths = scannerPaths;
+        this.imageName = imageName;
+        this.logger = runContext.getLogger();
+    }
+
+    public String execute(final FilePath scannerBinFile) throws AbortException {
+        try {
+            final FilePath scannerJsonOutputFile =
+                    this.scannerPaths.getBaseFolder().child("inlinescan.json");
+            SysdigImageScanningProcessBuilder processBuilder =
+                    createProcessBuilder(scannerBinFile, scannerJsonOutputFile);
+
+            logger.logInfo("Executing: " + String.join(" ", processBuilder.toCommandLineArguments()));
+            logger.logInfo("Waiting for scanner execution to be completed...");
+            int scannerExitCode = processBuilder.launchAndWait(this.runContext.getLauncher());
+            logger.logInfo(String.format("Scanner exit code: %d", scannerExitCode));
+
+            String jsonOutput = "";
+            if (scannerJsonOutputFile.exists()) jsonOutput = scannerJsonOutputFile.readToString();
+            logger.logDebug("Inline scan JSON output:\n" + jsonOutput);
+
+            if (scannerExitCode == 2) {
+                jsonOutput = "{error:\"Wrong parameters in call to inline scanner\"}";
+            } else if (scannerExitCode == 3) {
+                jsonOutput =
+                        "{error:\"Unexpected error when executing scan. Check that the API token is provided and is valid for the specified URL.\"}";
+            } else if (scannerExitCode != 0 && scannerExitCode != 1) {
+                throw new Exception("Cannot manage return code");
+            }
+
+            return jsonOutput;
+        } catch (Exception e) {
+            throw new AbortException("Error executing inlinescan binary: " + e);
+        }
+    }
+
+    private SysdigImageScanningProcessBuilder createProcessBuilder(
+            FilePath scannerBinFile, FilePath scannerJsonOutputFile) {
+        SysdigImageScanningProcessBuilder processBuilder = new SysdigImageScanningProcessBuilder(
+                        scannerBinFile.getRemote(), this.config.getSysdigToken())
+                .withExtraEnvVars(this.runContext.getEnvVars())
+                .withEngineURL(this.config.getEngineurl())
+                .withDBPath(this.scannerPaths.getDatabaseFolder().getRemote())
+                .withCachePath(this.scannerPaths.getCacheFolder().getRemote())
+                .withScanResultOutputPath(scannerJsonOutputFile.getRemote())
+                .withConsoleLog()
+                .withExtraParametersSeparatedBySpace(this.config.getInlineScanExtraParams())
+                .withPoliciesToApplySeparatedBySpace(this.config.getPoliciesToApply())
+                .withStdoutRedirectedTo(this.logger)
+                .withStderrRedirectedTo(this.logger)
+                .withLogLevel(
+                        config.getDebug()
+                                ? SysdigImageScanningProcessBuilder.LogLevel.DEBUG
+                                : SysdigImageScanningProcessBuilder.LogLevel.INFO)
+                .withTLSVerification(config.getEngineverify());
+
+        return processBuilder.withImageToScan(imageName);
+    }
+}

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerPaths.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerPaths.java
@@ -1,0 +1,52 @@
+/*
+Copyright (C) 2016-2024 Sysdig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner;
+
+import hudson.FilePath;
+import java.io.Serializable;
+
+/** Holds the folder hierarchy used by a single scanner execution. */
+public class ScannerPaths implements Serializable {
+    private static final String SCANNER_EXEC_FOLDER_BASE_PATH_PATTERN = "sysdig-secure-scan-%d";
+    private final FilePath baseFolder;
+    private final FilePath databaseFolder;
+    private final FilePath cacheFolder;
+
+    public ScannerPaths(final FilePath basePath) {
+        this.baseFolder =
+                basePath.child(String.format(SCANNER_EXEC_FOLDER_BASE_PATH_PATTERN, System.currentTimeMillis()));
+        this.databaseFolder = baseFolder.child("db");
+        this.cacheFolder = baseFolder.child("cache");
+    }
+
+    public FilePath getBaseFolder() {
+        return this.baseFolder;
+    }
+
+    public FilePath getDatabaseFolder() {
+        return this.databaseFolder;
+    }
+
+    public FilePath getCacheFolder() {
+        return this.cacheFolder;
+    }
+
+    public void create() throws Exception {
+        this.baseFolder.mkdirs();
+        this.databaseFolder.mkdirs();
+        this.cacheFolder.mkdirs();
+    }
+}

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerVersionResolver.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerVersionResolver.java
@@ -1,0 +1,54 @@
+/*
+Copyright (C) 2016-2024 Sysdig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner;
+
+import com.google.common.base.Strings;
+import com.sysdig.jenkins.plugins.sysdig.application.vm.ImageScanningConfig;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Resolves which version of the Sysdig CLI scanner should be used, honoring the
+ * custom version configured by the user and falling back to a pinned version.
+ */
+public class ScannerVersionResolver {
+    private static final String FIXED_SCANNED_VERSION = "1.27.1";
+
+    private final ImageScanningConfig config;
+
+    public ScannerVersionResolver(@NonNull ImageScanningConfig config) {
+        this.config = config;
+    }
+
+    public String resolve() {
+        if (Strings.isNullOrEmpty(config.getCliVersionToApply())) {
+            return pinnedVersion();
+        }
+
+        if (!config.getCliVersionToApply().equals("custom")) {
+            return pinnedVersion();
+        }
+
+        if (config.getCustomCliVersion().isEmpty()) {
+            return pinnedVersion();
+        }
+
+        return config.getCustomCliVersion();
+    }
+
+    public String pinnedVersion() {
+        return FIXED_SCANNED_VERSION;
+    }
+}

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerBinaryProviderTest.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerBinaryProviderTest.java
@@ -1,0 +1,112 @@
+package com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sysdig.jenkins.plugins.sysdig.application.vm.ImageScanningConfig;
+import com.sysdig.jenkins.plugins.sysdig.domain.SysdigLogger;
+import com.sysdig.jenkins.plugins.sysdig.infrastructure.http.ExecutableDownloader;
+import com.sysdig.jenkins.plugins.sysdig.infrastructure.jenkins.RunContext;
+import hudson.FilePath;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+class ScannerBinaryProviderTest {
+    private static final String BASE = "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/1.27.1/";
+
+    private final ImageScanningConfig config = mock(ImageScanningConfig.class);
+    private final ExecutableDownloader downloader = mock(ExecutableDownloader.class);
+    private final RunContext runContext = mock(RunContext.class);
+
+    private ScannerBinaryProvider provider() {
+        when(runContext.getLogger()).thenReturn(mock(SysdigLogger.class));
+        return new ScannerBinaryProvider(runContext, downloader, config, new ScannerVersionResolver(config));
+    }
+
+    @Test
+    void whenALocalCliBinaryIsConfiguredItIsUsedWithoutDownloading() throws Exception {
+        FilePath configured = mock(FilePath.class);
+        when(configured.getRemote()).thenReturn("/ws/custom-scanner");
+        when(config.getScannerBinaryPath()).thenReturn("custom-scanner");
+        when(runContext.getPathFromWorkspace("custom-scanner")).thenReturn(configured);
+
+        assertSame(configured, provider().retrieve());
+        verify(downloader, never()).downloadExecutable(any(), any());
+    }
+
+    @Test
+    void whenNoScannerBinaryPathIsConfiguredItDownloadsThePinnedVersion() throws Exception {
+        FilePath downloaded = mock(FilePath.class);
+        when(downloaded.getRemote()).thenReturn("/ws/bin/inlinescan-1.27.1.bin");
+        when(config.getScannerBinaryPath()).thenReturn("");
+        when(downloader.downloadExecutable(any(URL.class), eq("inlinescan-1.27.1.bin")))
+                .thenReturn(downloaded);
+
+        assertSame(downloaded, provider().retrieve());
+        // The exact URL depends on the host OS/arch; assert the resolved version flows into it and the filename.
+        verify(downloader)
+                .downloadExecutable(ScannerBinaryProvider.downloadURLForVersion("1.27.1"), "inlinescan-1.27.1.bin");
+    }
+
+    @Test
+    void whenACustomVersionIsConfiguredItDownloadsThatVersion() throws Exception {
+        FilePath downloaded = mock(FilePath.class);
+        when(downloaded.getRemote()).thenReturn("/ws/bin/inlinescan-1.30.0.bin");
+        when(config.getScannerBinaryPath()).thenReturn("");
+        when(config.getCliVersionToApply()).thenReturn("custom");
+        when(config.getCustomCliVersion()).thenReturn("1.30.0");
+        when(downloader.downloadExecutable(any(URL.class), eq("inlinescan-1.30.0.bin")))
+                .thenReturn(downloaded);
+
+        assertSame(downloaded, provider().retrieve());
+        verify(downloader)
+                .downloadExecutable(ScannerBinaryProvider.downloadURLForVersion("1.30.0"), "inlinescan-1.30.0.bin");
+    }
+
+    @Test
+    void linuxAmd64() throws MalformedURLException {
+        assertEquals(
+                BASE + "linux/amd64/sysdig-cli-scanner",
+                ScannerBinaryProvider.downloadURLForVersion("1.27.1", "Linux", "amd64")
+                        .toString());
+    }
+
+    @Test
+    void linuxArm64() throws MalformedURLException {
+        assertEquals(
+                BASE + "linux/arm64/sysdig-cli-scanner",
+                ScannerBinaryProvider.downloadURLForVersion("1.27.1", "Linux", "aarch64")
+                        .toString());
+    }
+
+    @Test
+    void macAmd64() throws MalformedURLException {
+        assertEquals(
+                BASE + "darwin/amd64/sysdig-cli-scanner",
+                ScannerBinaryProvider.downloadURLForVersion("1.27.1", "Mac OS X", "x86_64")
+                        .toString());
+    }
+
+    @Test
+    void macArm64() throws MalformedURLException {
+        assertEquals(
+                BASE + "darwin/arm64/sysdig-cli-scanner",
+                ScannerBinaryProvider.downloadURLForVersion("1.27.1", "Mac OS X", "aarch64")
+                        .toString());
+    }
+
+    @Test
+    void unknownOsDefaultsToLinuxAndUnknownArchDefaultsToAmd64() throws MalformedURLException {
+        assertEquals(
+                BASE + "linux/amd64/sysdig-cli-scanner",
+                ScannerBinaryProvider.downloadURLForVersion("1.27.1", "Windows 11", "ppc64")
+                        .toString());
+    }
+}

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerVersionResolverTest.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerVersionResolverTest.java
@@ -1,0 +1,49 @@
+package com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import com.sysdig.jenkins.plugins.sysdig.application.vm.ImageScanningConfig;
+import org.junit.jupiter.api.Test;
+
+class ScannerVersionResolverTest {
+    private final String pinnedVersion = new ScannerVersionResolver(mock(ImageScanningConfig.class)).pinnedVersion();
+
+    private ImageScanningConfig configWith(String cliVersionToApply, String customCliVersion) {
+        ImageScanningConfig config = mock(ImageScanningConfig.class);
+        lenient().when(config.getCliVersionToApply()).thenReturn(cliVersionToApply);
+        lenient().when(config.getCustomCliVersion()).thenReturn(customCliVersion);
+        return config;
+    }
+
+    @Test
+    void whenCliVersionToApplyIsNullItReturnsThePinnedVersion() {
+        ScannerVersionResolver resolver = new ScannerVersionResolver(configWith(null, ""));
+        assertEquals(pinnedVersion, resolver.resolve());
+    }
+
+    @Test
+    void whenCliVersionToApplyIsEmptyItReturnsThePinnedVersion() {
+        ScannerVersionResolver resolver = new ScannerVersionResolver(configWith("", ""));
+        assertEquals(pinnedVersion, resolver.resolve());
+    }
+
+    @Test
+    void whenCliVersionToApplyIsNotCustomItReturnsThePinnedVersion() {
+        ScannerVersionResolver resolver = new ScannerVersionResolver(configWith("global", "9.9.9"));
+        assertEquals(pinnedVersion, resolver.resolve());
+    }
+
+    @Test
+    void whenCliVersionToApplyIsCustomButCustomVersionIsEmptyItReturnsThePinnedVersion() {
+        ScannerVersionResolver resolver = new ScannerVersionResolver(configWith("custom", ""));
+        assertEquals(pinnedVersion, resolver.resolve());
+    }
+
+    @Test
+    void whenCliVersionToApplyIsCustomWithACustomVersionItReturnsThatVersion() {
+        ScannerVersionResolver resolver = new ScannerVersionResolver(configWith("custom", "1.30.0"));
+        assertEquals("1.30.0", resolver.resolve());
+    }
+}

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/SysdigImageScanningProcessBuilderTest.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/SysdigImageScanningProcessBuilderTest.java
@@ -1,0 +1,117 @@
+package com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner.SysdigProcessBuilderBase.LogLevel;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SysdigImageScanningProcessBuilderTest {
+
+    private SysdigImageScanningProcessBuilder builder() {
+        return new SysdigImageScanningProcessBuilder("/path/to/scanner", "my-token");
+    }
+
+    @Test
+    void byDefaultItEmitsTheCliPathApiUrlLogLevelAndImage() {
+        List<String> args = builder().withImageToScan("ubuntu:22.04").toCommandLineArguments();
+
+        assertEquals("/path/to/scanner", args.get(0));
+        assertTrue(args.contains("--apiurl=https://secure.sysdig.com"));
+        assertTrue(args.contains("--loglevel=info"));
+        // The image is always the last argument
+        assertEquals("ubuntu:22.04", args.get(args.size() - 1));
+    }
+
+    @Test
+    void theApiTokenIsNeverPassedAsACommandLineArgument() {
+        List<String> args = builder().withImageToScan("ubuntu:22.04").toCommandLineArguments();
+        assertFalse(args.stream().anyMatch(arg -> arg.contains("my-token")));
+    }
+
+    @Test
+    void itEmitsTheEngineUrlOutputDbAndCachePaths() {
+        List<String> args = builder()
+                .withEngineURL("https://eu1.sysdig.com")
+                .withScanResultOutputPath("/tmp/out.json")
+                .withDBPath("/tmp/db")
+                .withCachePath("/tmp/cache")
+                .withImageToScan("alpine")
+                .toCommandLineArguments();
+
+        assertTrue(args.contains("--apiurl=https://eu1.sysdig.com"));
+        assertTrue(args.contains("--output=json-file=/tmp/out.json"));
+        assertTrue(args.contains("--dbpath=/tmp/db"));
+        assertTrue(args.contains("--cachepath=/tmp/cache"));
+    }
+
+    @Test
+    void debugLogLevelIsEmittedWhenConfigured() {
+        List<String> args = builder().withLogLevel(LogLevel.DEBUG).toCommandLineArguments();
+        assertTrue(args.contains("--loglevel=debug"));
+        assertFalse(args.contains("--loglevel=info"));
+    }
+
+    @Test
+    void skipTlsVerifyIsEmittedOnlyWhenVerificationIsDisabled() {
+        assertFalse(builder().withTLSVerification(true).toCommandLineArguments().contains("--skiptlsverify"));
+        assertTrue(builder().withTLSVerification(false).toCommandLineArguments().contains("--skiptlsverify"));
+    }
+
+    @Test
+    void consoleLogAndSeparateByLayerAreEmittedOnlyWhenEnabled() {
+        List<String> off = builder().toCommandLineArguments();
+        assertFalse(off.contains("--console-log"));
+        assertFalse(off.contains("--separate-by-layer"));
+
+        List<String> on = builder().withConsoleLog().withSeparateByLayer(true).toCommandLineArguments();
+        assertTrue(on.contains("--console-log"));
+        assertTrue(on.contains("--separate-by-layer"));
+    }
+
+    @Test
+    void eachConfiguredPolicyIsEmittedAsItsOwnFlag() {
+        List<String> args = builder()
+                .withPoliciesToApplySeparatedBySpace("policy-a policy-b")
+                .toCommandLineArguments();
+        assertTrue(args.contains("--policy=policy-a"));
+        assertTrue(args.contains("--policy=policy-b"));
+    }
+
+    @Test
+    void extraParametersArePlacedBeforeTheImage() {
+        List<String> args = builder()
+                .withExtraParametersSeparatedBySpace("--foo --bar")
+                .withImageToScan("alpine")
+                .toCommandLineArguments();
+
+        assertTrue(args.contains("--foo"));
+        assertTrue(args.contains("--bar"));
+        assertEquals("alpine", args.get(args.size() - 1));
+        assertTrue(args.indexOf("--foo") < args.indexOf("alpine"));
+    }
+
+    @Test
+    void blankPoliciesAndExtraParametersAreIgnored() {
+        List<String> args = builder()
+                .withPoliciesToApplySeparatedBySpace("   ")
+                .withExtraParametersSeparatedBySpace("   ")
+                .toCommandLineArguments();
+
+        assertFalse(args.stream().anyMatch(arg -> arg.startsWith("--policy=")));
+    }
+
+    @Test
+    void withMethodsAreImmutableAndDoNotMutateTheOriginalBuilder() {
+        SysdigImageScanningProcessBuilder original = builder();
+        original.withImageToScan("alpine").withConsoleLog().withSeparateByLayer(true);
+
+        List<String> args = original.toCommandLineArguments();
+        assertFalse(args.contains("--console-log"));
+        assertFalse(args.contains("--separate-by-layer"));
+        // image untouched on the original (defaults to empty)
+        assertEquals("", args.get(args.size() - 1));
+    }
+}


### PR DESCRIPTION
CLI version resolution (pinned vs user-configured custom) was private logic buried in the scanner, untestable. Pulling it into its own class makes the pinned/custom branching unit-testable in isolation.

Also updates the plugin parent POM to a newer version to fix vulnerabilities.