### PR TITLE
chore: organize justfile into groups and switch devshell to prek

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,11 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
+    -   id: check-json
     -   id: check-added-large-files
+    -   id: detect-private-key
+    -   id: mixed-line-ending
+        args: [--fix=lf]
 - repo: local
   hooks:
       - id: just-format

--- a/flake.nix
+++ b/flake.nix
@@ -33,12 +33,12 @@
             jdt-language-server
             maven
             jdk
-            pre-commit
+            prek
             just
           ];
 
           shellHook = ''
-            pre-commit install
+            prek install --overwrite
           '';
         };
         formatter = pkgs.nixfmt-rfc-style;

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 # Help commands
+[private]
 default:
     @just --list
 

--- a/justfile
+++ b/justfile
@@ -47,15 +47,15 @@ update-jenkins-version:
     #!/usr/bin/env bash
     set -euo pipefail
     echo "Fetching latest unmaintained LTS Jenkins version..."
-    version=$(curl -s https://endoflife.date/api/v1/products/jenkins/ | jq -r '.result.releases | map(select(.isMaintained == false)) | first | .latest.name')
-    baseline=$(echo "$version" | cut -d. -f1-2)
+    version=$(curl --silent https://endoflife.date/api/v1/products/jenkins/ | jq -r '.result.releases | map(select(.isMaintained == false)) | first | .latest.name')
+    baseline=$(echo "$version" | cut --delimiter=. --fields=1-2)
     echo "Found Jenkins version: $version (Baseline: $baseline)"
     echo "Fetching latest BOM version for bom-${baseline}.x..."
-    bom_version=$(curl -s "https://repo.jenkins-ci.org/public/io/jenkins/tools/bom/bom-${baseline}.x/maven-metadata.xml" | grep -oPm1 "(?<=<latest>)[^<]+")
+    bom_version=$(curl --silent "https://repo.jenkins-ci.org/public/io/jenkins/tools/bom/bom-${baseline}.x/maven-metadata.xml" | grep --only-matching --perl-regexp --max-count=1 "(?<=<latest>)[^<]+")
     echo "Found BOM version: $bom_version"
-    sed -i "s|<jenkins.baseline>.*</jenkins.baseline>|<jenkins.baseline>${baseline}</jenkins.baseline>|" pom.xml
-    sed -i "s|<jenkins.version>.*</jenkins.version>|<jenkins.version>${version}</jenkins.version>|" pom.xml
-    sed -i "/<artifactId>bom-\${jenkins.baseline}.x<\/artifactId>/,+2 s|<version>.*</version>|<version>${bom_version}</version>|" pom.xml
+    sed --in-place "s|<jenkins.baseline>.*</jenkins.baseline>|<jenkins.baseline>${baseline}</jenkins.baseline>|" pom.xml
+    sed --in-place "s|<jenkins.version>.*</jenkins.version>|<jenkins.version>${version}</jenkins.version>|" pom.xml
+    sed --in-place "/<artifactId>bom-\${jenkins.baseline}.x<\/artifactId>/,+2 s|<version>.*</version>|<version>${bom_version}</version>|" pom.xml
     echo "Updated pom.xml to Jenkins $version, Baseline $baseline, BOM $bom_version"
 
 # Update parent POM to latest version
@@ -79,7 +79,7 @@ update-sysdig-cli-version:
     #!/usr/bin/env bash
     set -euo pipefail
     echo "Fetching latest sysdig version…"
-    latest=$(curl -sfSL https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
+    latest=$(curl --silent --fail --show-error --location https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)
     echo "Latest: $latest"
-    sed -i -E 's/(private static final String FIXED_SCANNED_VERSION = ")([^"]+)(")/\1'"$latest"'\3/' src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerVersionResolver.java
+    sed --in-place --regexp-extended 's/(private static final String FIXED_SCANNED_VERSION = ")([^"]+)(")/\1'"$latest"'\3/' src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerVersionResolver.java
     echo "Version updated"

--- a/justfile
+++ b/justfile
@@ -3,28 +3,46 @@ default:
     @just --list
 
 # Run all checks
+[group('build')]
 check: format-check verify
 
 # Verify project (clean build, tests, spotless check, javadoc)
+[group('build')]
 verify:
     mvn clean spotless:check verify javadoc:jar
 
+# Run tests
+[group('build')]
+test:
+    mvn test
+
 # Format code
+[group('format')]
 format:
     mvn spotless:apply
 
 # Check formatting without modifying
+[group('format')]
 format-check:
     mvn spotless:check
 
-# Run tests
-test:
-    mvn test
+# Run Jenkins locally with the plugin installed (http://localhost:8080/jenkins)
+[group('dev')]
+dev-run:
+    mvn clean hpi:run
+
+# Prepare and perform Maven release
+[group('dev')]
+[confirm('This will prepare and perform a Maven release. Continue?')]
+release: format-check
+    mvn release:prepare release:perform
 
 # Update everything: jenkins, parent pom, deps, flake, sysdig cli
+[group('update')]
 update: update-jenkins-version update-parent-pom update-dependencies update-flake update-sysdig-cli-version
 
 # Update to latest unmaintained LTS Jenkins version
+[group('update')]
 update-jenkins-version:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -41,18 +59,22 @@ update-jenkins-version:
     echo "Updated pom.xml to Jenkins $version, Baseline $baseline, BOM $bom_version"
 
 # Update parent POM to latest version
+[group('update')]
 update-parent-pom:
     mvn versions:update-parent -DgenerateBackupPoms=false
 
 # Update dependencies to latest versions
+[group('update')]
 update-dependencies:
     mvn versions:use-latest-versions
 
 # Update nix flake
+[group('update')]
 update-flake:
     -nix flake update
 
 # Update sysdig CLI scanner version
+[group('update')]
 update-sysdig-cli-version:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -61,11 +83,3 @@ update-sysdig-cli-version:
     echo "Latest: $latest"
     sed -i -E 's/(private static final String FIXED_SCANNED_VERSION = ")([^"]+)(")/\1'"$latest"'\3/' src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/ScannerVersionResolver.java
     echo "Version updated"
-
-# Run Jenkins locally with the plugin installed (http://localhost:8080/jenkins)
-dev-run:
-    mvn clean hpi:run
-
-# Prepare and perform Maven release
-release:
-    mvn release:prepare release:perform


### PR DESCRIPTION
Justfile recipes were flat and hard to scan; grouping them makes `just --list` navigable as the recipe set grows. Also hardens the release path and modernizes the local hooks tooling.

- Recipes grouped by intent (build, format, dev, update) via `[group(...)]`.
- `release` now depends on `format-check` and prompts for confirmation, so a spotless failure or a stray invocation aborts before touching the release lifecycle. Tests aren't re-run since `release:prepare` already does.
- Short flags in the bash recipes expanded to long form for readability.
- Devshell swaps `pre-commit` for `prek` and installs with `--overwrite` on entry, making the hook install idempotent and fixing the stale nix-store hook path that broke commits.
- Added `check-json`, `detect-private-key`, and `mixed-line-ending --fix=lf` hooks for basic safety and consistency.