### PR TITLE
chore: Address scanner-version-testing review feedback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,14 @@ The project includes a `justfile` with useful commands:
   just verify
   ```
 
+> **Note:** The `scanner` recipes (`just --list`) assume the GNU versions of `sed`/`date`
+> (provided by the Nix devshell — run them from `nix develop`). Bumping the scanner testing
+> window with `just update-cli-scanner` / `just update-oldest-cli-scanner` only rewrites the
+> version markers; regenerating the checked-in fixtures with `just generate-scanner-fixtures`
+> (also pulled in by `just update`) runs a real scan, so it requires network access and a
+> valid `SECURE_API_TOKEN` (optionally `SECURE_API_URL`). A plain `mvn`/`just` build and the
+> test suite run against the committed fixtures and need neither.
+
 ## Making Changes
 
 - The project follows the **Ports and Adapters (Hexagonal) Architecture**. Please ensure that your contributions respect this design pattern to maintain modularity and separation of concerns.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,13 +66,13 @@ The project includes a `justfile` with useful commands:
   just verify
   ```
 
-> **Note:** The `scanner` recipes (`just --list`) assume the GNU versions of `sed`/`date`
-> (provided by the Nix devshell — run them from `nix develop`). Bumping the scanner testing
-> window with `just update-cli-scanner` / `just update-oldest-cli-scanner` only rewrites the
-> version markers; regenerating the checked-in fixtures with `just generate-scanner-fixtures`
-> (also pulled in by `just update`) runs a real scan, so it requires network access and a
-> valid `SECURE_API_TOKEN` (optionally `SECURE_API_URL`). A plain `mvn`/`just` build and the
-> test suite run against the committed fixtures and need neither.
+> **Note:** The `scanner` recipes (`just --list`) rely on GNU `sed`/`date`/`grep`, `curl`,
+> `jq` and `gzip`, all provided by the Nix devshell — run them from `nix develop`. Bumping the
+> scanner testing window with `just update-cli-scanner` / `just update-oldest-cli-scanner` only
+> rewrites the version markers; regenerating the checked-in fixtures with
+> `just generate-scanner-fixtures` (also pulled in by `just update`) runs a real scan, so it
+> requires network access and a valid `SECURE_API_TOKEN` (optionally `SECURE_API_URL`). A plain
+> `mvn`/`just` build and the test suite run against the committed fixtures and need neither.
 
 ## Making Changes
 

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,13 @@
             jdk
             prek
             just
+            # Tooling the justfile `scanner` recipes rely on (GNU sed/date/grep, curl, jq, gzip).
+            coreutils
+            gnused
+            gnugrep
+            curl
+            jq
+            gzip
           ];
 
           shellHook = ''

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/TestMother.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/TestMother.java
@@ -128,14 +128,6 @@ public class TestMother {
         return loadGzippedScanResult(OLDEST_FIXTURE);
     }
 
-    /**
-     * @return whether the oldest-version fixture has been generated and checked in. Tests use this
-     *     to skip (rather than fail) until a developer runs {@code just generate-scanner-fixtures}.
-     */
-    public static boolean oldestScannerFixtureAvailable() {
-        return TestMother.class.getClassLoader().getResource(OLDEST_FIXTURE) != null;
-    }
-
     private static JsonScanResultV1 loadGzippedScanResult(String resourcePath) {
         InputStream imageStream = TestMother.class.getClassLoader().getResourceAsStream(resourcePath);
         assertNotNull(imageStream, "Missing fixture: " + resourcePath + " (run `just generate-scanner-fixtures`)");

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/report/v1/JsonScanResultTest.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/report/v1/JsonScanResultTest.java
@@ -1,7 +1,6 @@
 package com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner.report.v1;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.sysdig.jenkins.plugins.sysdig.TestMother;
 import com.sysdig.jenkins.plugins.sysdig.domain.vm.scanresult.*;
@@ -214,10 +213,6 @@ class JsonScanResultTest {
 
     @Test
     void whenParsingOldestMaintainedScannerOutputThePluginProducesAValidPopulatedResult() {
-        assumeTrue(
-                TestMother.oldestScannerFixtureAvailable(),
-                "oldest-version fixture not generated yet; run `just generate-scanner-fixtures`");
-
         // Recorded raw output from the oldest still-maintained CLI scanner (TestMother.OLDEST_FIXTURE_VERSION).
         // Proves the plugin keeps working against an older output format.
         ScanResult result = TestMother.scanResultFromOldestScanner().toDomain().orElseThrow();


### PR DESCRIPTION
Follow-up to #162.

Make the newest and oldest fixture parse tests symmetric. Both fixtures are checked in, so the oldest test no longer skips via `assumeTrue` while the newest hard-fails — a missing fixture is a genuine failure for both, and the dead `oldestScannerFixtureAvailable()` helper is gone.

Provide the tooling the `scanner` justfile recipes depend on via the Nix devshell — GNU `sed`/`date`/`grep`, `curl`, `jq` and `gzip` — instead of just assuming it is present (notably GNU `sed`/`date` on macOS, where the system defaults are BSD).

Document in CONTRIBUTING that regenerating the checked-in fixtures — and therefore `just update` — needs network access and `SECURE_API_TOKEN`, whereas a normal build and the test suite run against the committed fixtures without either.