### PR TITLE
fix(iac): scan the workspace when no path is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ The parameter names and semantics are kept backwards compatible, matching the `s
 | Option                        | Pipeline parameter    | Description                                                                                 | Default         |
 |-------------------------------|-----------------------|---------------------------------------------------------------------------------------------|-----------------|
 | Sysdig Secure API Credentials | `engineCredentialsId` | Jenkins credential holding the Sysdig Secure API token. **Mandatory.**                      | |
-| Path to scan                  | `path`                | Directory or file containing the IaC manifests to scan.                                     | `.` (workspace) |
+| Path to scan                  | `path`                | Directory or file containing the IaC manifests to scan. Relative paths resolve against the workspace. | `.` (workspace) |
 | Recursive                     | `isRecursive`         | Scan the given path recursively.                                                            | `true`          |
 | List unsupported resources    | `listUnsupported`     | Include unsupported resources in the scan output.                                           | `false`         |
 | Severity threshold            | `severityThreshold`   | Minimum severity that fails the build (`high`, `medium`, `low`, `never`).                    | `high`          |

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/jenkins/iac/entrypoint/IaCScanningBuilder.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/jenkins/iac/entrypoint/IaCScanningBuilder.java
@@ -141,6 +141,9 @@ public class IaCScanningBuilder extends Builder implements SimpleBuildStep {
                 .withSeverity(SysdigIaCScanningProcessBuilder.Severity.fromString(severityThreshold))
                 .withScanResultOutputPath(scanResultOutputFile.getRemote())
                 .withPathsToScan(path)
+                // Relative paths, and the default of the current directory, are meant to be the
+                // workspace's; without this the scanner walks whatever directory the agent's JVM sits in.
+                .withWorkingDirectory(runContext.getPathFromWorkspace())
                 .withStdoutRedirectedTo(runContext.getLogger())
                 .withStderrRedirectedTo(runContext.getLogger());
 
@@ -187,7 +190,7 @@ public class IaCScanningBuilder extends Builder implements SimpleBuildStep {
             int exitCode = processBuilder.launchAndWait(runContext.getLauncher());
             logger.logInfo(String.format("Process finished with status %d", exitCode));
 
-            reportAndAttachScanResult(run, logger, scanResultOutputFile);
+            reportAndAttachScanResult(run, logger, scanResultOutputFile, workspace);
 
             switch (exitCode) {
                 case 0:
@@ -263,7 +266,8 @@ public class IaCScanningBuilder extends Builder implements SimpleBuildStep {
      * that renders the result tables on the build page. Never alters the build result: the exit code
      * remains the source of truth for pass/fail.
      */
-    void reportAndAttachScanResult(Run<?, ?> run, SysdigLogger logger, FilePath scanResultOutputFile) {
+    void reportAndAttachScanResult(
+            Run<?, ?> run, SysdigLogger logger, FilePath scanResultOutputFile, FilePath workspace) {
         try {
             if (!scanResultOutputFile.exists()) return;
 
@@ -275,7 +279,9 @@ public class IaCScanningBuilder extends Builder implements SimpleBuildStep {
             if (scanResult.isEmpty()) return;
 
             logScanResultSummary(logger, scanResult.get());
-            IaCAction.attachTo(run, json, path);
+            // An empty path means the workspace, which is what the report should name: "" would leave
+            // the page unable to say what the module paths in it are relative to.
+            IaCAction.attachTo(run, json, path.isBlank() ? workspace.getRemote() : path);
         } catch (Exception e) {
             logger.logWarn("Could not parse IaC scan result report: " + e.getMessage());
         }

--- a/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/SysdigIaCScanningProcessBuilder.java
+++ b/src/main/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/SysdigIaCScanningProcessBuilder.java
@@ -2,6 +2,7 @@ package com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner;
 
 import com.google.common.base.Strings;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class SysdigIaCScanningProcessBuilder extends SysdigProcessBuilderBase<SysdigIaCScanningProcessBuilder> {
@@ -37,9 +38,17 @@ public class SysdigIaCScanningProcessBuilder extends SysdigProcessBuilderBase<Sy
         return clone;
     }
 
+    /**
+     * Paths for the scanner to walk. Blank ones are dropped rather than passed on: the build step hands
+     * over its configured path as is, and that path is empty until someone fills it in, which would
+     * otherwise reach the scanner as an empty path instead of falling back to the current directory.
+     */
     public SysdigIaCScanningProcessBuilder withPathsToScan(String... pathListToScan) {
         SysdigIaCScanningProcessBuilder clone = this.clone();
-        clone.pathsToScan.addAll(List.of(pathListToScan));
+        Arrays.stream(pathListToScan)
+                .filter(path -> !Strings.nullToEmpty(path).isBlank())
+                .map(String::trim)
+                .forEach(clone.pathsToScan::add);
         return clone;
     }
 

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/e2e/IaCScanE2EFreestyleTests.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/e2e/IaCScanE2EFreestyleTests.java
@@ -114,6 +114,26 @@ class IaCScanE2EFreestyleTests {
                 .toList();
     }
 
+    /**
+     * With no path configured the scan has to walk the workspace: the process runs there and gets the
+     * current directory as its path, instead of an empty path in whatever directory the agent's JVM
+     * happens to sit in.
+     */
+    @Test
+    void testTheDefaultPathScansTheWorkspace() throws Exception {
+        var project = helpers.createFreestyleProjectWithIaCScanBuilder()
+                .withConfig(b -> b.setEngineCredentialsId("sysdig-secure"))
+                .build();
+
+        var build = jenkins.buildAndAssertStatus(Result.FAILURE, project);
+
+        var workspace = project.getSomeWorkspace();
+        assertNotNull(workspace);
+        jenkins.assertLogContains("--recursive --severity-threshold=high .", build);
+        jenkins.assertLogContains("[" + workspace.getName() + "] $ ", build);
+        jenkins.assertLogContains("Scanning paths paths=[\".\"]", build);
+    }
+
     @Test
     void testFreestyleWithAllConfigs() throws Exception {
         var project = helpers.createFreestyleProjectWithIaCScanBuilder()

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/jenkins/iac/entrypoint/IaCScanningBuilderTest.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/jenkins/iac/entrypoint/IaCScanningBuilderTest.java
@@ -115,9 +115,9 @@ class IaCScanningBuilderTest {
         IaCScanningBuilder builder = builderScanning("infra");
 
         builder.reportAndAttachScanResult(
-                build, mock(SysdigLogger.class), workspace().child("does-not-exist.json"));
+                build, mock(SysdigLogger.class), workspace().child("does-not-exist.json"), workspace());
         FilePath empty = IaCScanningBuilder.createScanResultOutputFile(workspace());
-        builder.reportAndAttachScanResult(build, mock(SysdigLogger.class), empty);
+        builder.reportAndAttachScanResult(build, mock(SysdigLogger.class), empty, workspace());
 
         assertTrue(build.getActions(IaCAction.class).isEmpty());
     }
@@ -130,8 +130,8 @@ class IaCScanningBuilderTest {
 
         FilePath report = IaCScanningBuilder.createScanResultOutputFile(workspace());
         report.write(TestMother.iacScanResultJson(), "UTF-8");
-        builder.reportAndAttachScanResult(build, mock(SysdigLogger.class), report);
-        builder.reportAndAttachScanResult(build, mock(SysdigLogger.class), report);
+        builder.reportAndAttachScanResult(build, mock(SysdigLogger.class), report, workspace());
+        builder.reportAndAttachScanResult(build, mock(SysdigLogger.class), report, workspace());
 
         var actions = build.getActions(IaCAction.class);
         assertEquals(2, actions.size());
@@ -157,7 +157,7 @@ class IaCScanningBuilderTest {
 
         FilePath report = IaCScanningBuilder.createScanResultOutputFile(workspace());
         report.write(CRITICAL_FINDING_REPORT, "UTF-8");
-        builderScanning("infra").reportAndAttachScanResult(build, logger, report);
+        builderScanning("infra").reportAndAttachScanResult(build, logger, report, workspace());
 
         var lines = ArgumentCaptor.forClass(String.class);
         verify(logger, atLeastOnce()).logInfo(lines.capture());
@@ -165,6 +165,25 @@ class IaCScanningBuilderTest {
 
         assertTrue(summary.contains("Failed controls by severity: Critical=1, High=1"), summary);
         assertTrue(summary.contains("2 failed control(s) across 3 resource violation(s)"), summary);
+    }
+
+    /**
+     * With no path configured the scan walks the workspace, so that is what the report has to name: the
+     * step's own (empty) setting would leave the page unable to say what its module paths are relative to.
+     */
+    @Test
+    void aScanWithoutAConfiguredPathReportsTheWorkspace() throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+        IaCScanningBuilder builder = builderScanning("");
+
+        FilePath report = IaCScanningBuilder.createScanResultOutputFile(workspace());
+        report.write(TestMother.iacScanResultJson(), "UTF-8");
+        builder.reportAndAttachScanResult(build, mock(SysdigLogger.class), report, workspace());
+
+        IaCAction attached = build.getActions(IaCAction.class).get(0);
+        assertEquals(workspace().getRemote(), attached.getScannedPath());
+        assertTrue(attached.getDisplayName().contains("workspace"), attached.getDisplayName());
     }
 
     /**

--- a/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/SysdigIaCScanningProcessBuilderTest.java
+++ b/src/test/java/com/sysdig/jenkins/plugins/sysdig/infrastructure/scanner/SysdigIaCScanningProcessBuilderTest.java
@@ -1,0 +1,50 @@
+package com.sysdig.jenkins.plugins.sysdig.infrastructure.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SysdigIaCScanningProcessBuilderTest {
+
+    private SysdigIaCScanningProcessBuilder builder() {
+        return new SysdigIaCScanningProcessBuilder("/path/to/scanner", "my-token");
+    }
+
+    @Test
+    void byDefaultItScansTheCurrentDirectory() {
+        List<String> args = builder().toCommandLineArguments();
+
+        assertEquals("/path/to/scanner", args.get(0));
+        assertTrue(args.contains("--iac"));
+        assertEquals(".", args.get(args.size() - 1), "the path to scan is the last argument");
+    }
+
+    /**
+     * The step passes its configured path straight through, and that path is empty until someone fills
+     * it in. An empty argument is not "no argument": it left the scanner with a path of "" instead of
+     * the current directory.
+     */
+    @Test
+    void anEmptyConfiguredPathFallsBackToTheCurrentDirectory() {
+        assertEquals(".", lastPathOf(builder().withPathsToScan("")));
+        assertEquals(".", lastPathOf(builder().withPathsToScan("   ")));
+        assertEquals(".", lastPathOf(builder().withPathsToScan((String) null)));
+    }
+
+    @Test
+    void itKeepsEveryConfiguredPathAndTrimsThem() {
+        List<String> args =
+                builder().withPathsToScan("infra/", "  charts/  ", "").toCommandLineArguments();
+
+        assertEquals(List.of("infra/", "charts/"), args.subList(args.size() - 2, args.size()));
+        assertFalse(args.contains(""), "no empty path argument");
+    }
+
+    private static String lastPathOf(SysdigIaCScanningProcessBuilder builder) {
+        List<String> args = builder.toCommandLineArguments();
+        return args.get(args.size() - 1);
+    }
+}


### PR DESCRIPTION
Stacked on #168.

A step with no `path` configured was not scanning the workspace, which is what the README documents and the
only thing that makes sense for a build. Two things went wrong at once, both visible in a real build's console:

```
$ /…/workspace/iac/bin/sysdig-cli-scanner --iac … --recursive --severity-threshold=high
INF Scanning paths paths=[""]
```

The step passes its configured path through as is, and an empty string is still an argument, so the `.`
fallback never applied and the scanner got an empty path. And nothing ever set the process working directory,
so the "current directory" that the empty path (or any relative path, such as the documented
`path: 'infrastructure/'`) resolved against was wherever the agent's JVM happened to be started — for an inbound
agent, its own installation directory.

Blank paths are now dropped before the fallback and the scanner runs in the workspace, so `.` and relative paths
mean the workspace. The report page also names the workspace as the scan root in that case, since that is what
the module paths in it are relative to; with a path configured nothing changes.

Anyone who had worked around this by pointing `path` at an absolute directory keeps working — absolute paths are
unaffected. Anyone relying on the old (accidental) behaviour of scanning the agent's own directory will now scan
the workspace instead.