### PR TITLE
chore: bump Jenkins baseline to 2.555.3, build on JDK 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,5 +7,5 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],
-    [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 25],
 ])

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     }:
     let
       setJavaVersion = final: prev: {
-        jdk = prev.temurin-bin-17;
+        jdk = prev.temurin-bin-21;
         jdt-language-server = prev.jdt-language-server.override { jdk = prev.jdk; };
       };
     in

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>sysdig-secure</artifactId>
-  <version>3.5.2-SNAPSHOT</version>
+  <version>3.6.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Sysdig Secure Container Image Scanner Plugin</name>
   <description>Integrates Jenkins with the Sysdig Secure Image Scanner to scan OCI images</description>
@@ -41,8 +41,8 @@
   <properties>
     <!-- You can check out which versions are being used per version in https://stats.jenkins.io/pluginversions/sysdig-secure.html -->
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.541</jenkins.baseline>
-    <jenkins.version>2.541.3</jenkins.version>
+    <jenkins.baseline>2.555</jenkins.baseline>
+    <jenkins.version>2.555.3</jenkins.version>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/mark-a-plugin-incompatible/ -->
     <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
@@ -57,7 +57,7 @@
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
         <!-- You can find your version for the selected baseline in: https://repo.jenkins-ci.org/public/io/jenkins/tools/bom/ -->
-        <version>6783.v88c6c30f4b_db_</version>
+        <version>6815.v1fb_2a_fee3765</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Jenkins 2.555.x requires Java 21+ on both controller and agents — Java 17 is dropped upstream — so staying on the 2.541.x baseline would keep us shipping against a core our users can no longer run on 17. This lifts the baseline to 2.555.3 (pulling in the `bom-2.555.x`), moves the build/dev JDK to temurin 21, and switches the CI matrix off 17 to the two JDKs 2.555.x actually supports (21 and 25, both available on ci.jenkins.io agents).

Cut as **3.6.0** (minor): it raises the minimum supported Jenkins/Java rather than changing plugin behaviour, so it's not a bugfix (patch) and doesn't break the plugin's own API (major).